### PR TITLE
Improve docs, continuous integration and development

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__.'/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
     ->setRules([
         '@PSR2' => true,
         '@PHP70Migration' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,15 +1,18 @@
 filter:
-    excluded_paths:
-        - 'tests/*'
-        - 'vendor/*'
+  excluded_paths:
+    - 'tests/'
+    - 'vendor/'
 
-checks:
-    php:
-        code_rating: true
-        duplication: true
-
-tools:
-    php_code_sniffer:
-        config:
-            standard: "PSR2"
-    external_code_coverage: true
+build:
+  nodes:
+    php73:
+      environment:
+        php:
+          version: "7.3"
+      tests:
+        override:
+          - php-scrutinizer-run --enable-security-analysis
+          - command: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+            coverage:
+              file: coverage.clover
+              format: clover

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,6 +9,8 @@ build:
       environment:
         php:
           version: "7.3"
+          pecl_extensions:
+            - "zip"
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,29 @@
 language: php
 
-# php compatibility
-php:
-  - 7.2
-  - 7.3
-
-env:
-  - FULLBUILD_PHP_VERSION: 7.3
-
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
+
+# php compatibility
+php:
+  - "7.2"
+  - "7.3"
 
 cache:
   - directories:
     - $HOME/.composer
 
 before_script:
-  # - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-dist
   - phpenv config-rm xdebug.ini
+  - travis_retry composer install --no-interaction --prefer-dist
+  - mkdir -p build
 
 script:
-  - mkdir -p build
   - vendor/bin/phplint
-  - |
-    if [[ "${FULLBUILD_PHP_VERSION}" == "${TRAVIS_PHP_VERSION}" ]]; then
-      vendor/bin/php-cs-fixer fix --verbose
-      vendor/bin/phpcbf --colors -sp src/ tests/
-      php -dzend_extension=xdebug.so vendor/bin/phpunit --testdox --verbose --coverage-text --coverage-clover=build/tests/coverage.xml
-      vendor/bin/phpstan.phar analyse --no-progress --level max src/ tests/
-    else
-      vendor/bin/phpunit --testdox --verbose
-    fi
-
-after_success:
-  - |
-    if [[ "${FULLBUILD_PHP_VERSION}" == "${TRAVIS_PHP_VERSION}" ]]; then
-      mkdir -p build/ocular
-      travis_retry composer require scrutinizer/ocular --working-dir=build/ocular --dev --no-interaction --prefer-dist
-      build/ocular/vendor/bin/ocular code-coverage:upload --format=php-clover build/tests/coverage.xml
-    fi
+  - vendor/bin/php-cs-fixer fix --verbose --dry-run
+  - vendor/bin/phpcs --colors -sp src/ tests/
+  - vendor/bin/phpunit --testdox --verbose
+  - vendor/bin/phpstan.phar analyse --no-progress --verbose --level max src/ tests/
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,9 @@
         ],
         "dev:test": [
             "vendor/bin/phplint",
+            "@dev:check-style",
             "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "vendor/bin/phpstan analyse --verbose --level max src/ tests/"
+            "vendor/bin/phpstan analyse --verbose --no-progress --level max src/ tests/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,21 +1,29 @@
 # phpcfdi/sat-ws-descarga-masiva To Do List
 
-- Crear documentación de la librería y README, CI, etc.
-
-- Crear un objeto para los valores del servicio de verificación de CodigoEstadoSolicitud
- 
-- Crear un objeto para los valores del servicio de verificación de EstadoSolicitud 
-
-- Crear lector de archivos ZIP de Metadata
-
-- Crear lector de archivos ZIP de CFDI
-
 - Mover la dependencia del certificado a phpcfdi/sat-credentials una vez que exista el proyecto
 
+- Mover el script de consumo con credenciales válidas a su propio proyecto dependiente de este.
+
 - Llevar el code coverage a 100% con test unitarios
-    2019-08-08: Current 84.04% 
+    2019-08-09: Current 86% 
+    2019-08-08: Current 84% 
 
 ## Tareas resueltas
+
+- Crear documentación de la librería y README, CI, etc.
+    2019-09-09: Hecho!
+
+- Crear un objeto para los valores del servicio de verificación de CodigoEstadoSolicitud
+    2019-09-09: Hecho!
+ 
+- Crear un objeto para los valores del servicio de verificación de EstadoSolicitud 
+    2019-09-09: Hecho!
+
+- Crear lector de archivos ZIP de Metadata
+    2019-09-09: Hecho!
+
+- Crear lector de archivos ZIP de CFDI
+    2019-09-09: Hecho!
 
 - Mejorar los objetos Result para que puedan compartir la misma lógica donde la comparten
     2019-08-08: Se creó el StatusCode para exponer el código y mensaje en los servicios comúnes

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php" colors="true" verbose="true" cacheTokens="false">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+         bootstrap="./tests/bootstrap.php" colors="true" verbose="true" cacheResultFile="./build/phpunit.result.cache">
     <testsuites>
         <testsuite name="Default">
             <directory>./tests/</directory>

--- a/tests/Scripts/Actions/Credentials.php
+++ b/tests/Scripts/Actions/Credentials.php
@@ -34,7 +34,7 @@ class Credentials extends AbstractAction
         }
     }
 
-    public function help(): void
+    public function runHelp(): void
     {
         $this->stdout('return information about current credentials');
     }

--- a/tests/Scripts/Actions/Download.php
+++ b/tests/Scripts/Actions/Download.php
@@ -48,7 +48,7 @@ class Download extends AbstractAction
         ]);
     }
 
-    public function help(): void
+    public function runHelp(): void
     {
         $this->stdout('Download a package id, the result contains codes information and zero or one package stream');
         $this->stdout(...$this->createArguments()->toArray());

--- a/tests/Scripts/Actions/Help.php
+++ b/tests/Scripts/Actions/Help.php
@@ -22,7 +22,7 @@ class Help extends AbstractAction
         ]);
     }
 
-    public function help(): void
+    public function runHelp(): void
     {
         $this->run();
     }

--- a/tests/Scripts/Actions/Query.php
+++ b/tests/Scripts/Actions/Query.php
@@ -67,7 +67,7 @@ class Query extends AbstractAction
         ]);
     }
 
-    public function help(): void
+    public function runHelp(): void
     {
         $this->stdout('Perform a request, uses the following parameters:');
         $this->stdout(...$this->createArguments()->toArray());

--- a/tests/Scripts/Actions/Verify.php
+++ b/tests/Scripts/Actions/Verify.php
@@ -41,7 +41,7 @@ class Verify extends AbstractAction
         ]);
     }
 
-    public function help(): void
+    public function runHelp(): void
     {
         $this->stdout('Verify a request id, the result contains codes information and zero, one or more package id');
         $this->stdout(...$this->createArguments()->toArray());

--- a/tests/Scripts/CLI/ActionInterface.php
+++ b/tests/Scripts/CLI/ActionInterface.php
@@ -8,5 +8,5 @@ interface ActionInterface
 {
     public function run(string ...$parameters): void;
 
-    public function help(): void;
+    public function runHelp(): void;
 }

--- a/tests/Scripts/sat-ws-descarga-masiva.php
+++ b/tests/Scripts/sat-ws-descarga-masiva.php
@@ -37,7 +37,7 @@ exit(call_user_func(
             /** @var CLI\ActionInterface $actionObject */
             $actionObject = new $actionClass($fielData, $printer, $outputDirectory);
             if ($askForHelp) {
-                $actionObject->help();
+                $actionObject->runHelp();
             } else {
                 $actionObject->run(...$unmatched);
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     public static function fileContents(string $filename): string
     {
-        return file_get_contents(static::filePath($filename)) ?: '';
+        /** @noinspection PhpUsageOfSilenceOperatorInspection */
+        return strval(@file_get_contents(static::filePath($filename))) ?: '';
     }
 
     public function createFielUsingTestingFiles(string $password = null): Fiel


### PR DESCRIPTION
Update strcrutinizer to recommended config
Update travis to:
- run phpcs instead of phpcbf
- test the same in all php versions
- do not report code coverage to scrutinizer
Update composer dev script dev:test to run dev:check-style
Fix PHPUnit XSD version and store cache file inside build/