### PR TITLE
Fix correct name and message for code request 5004

### DIFF
--- a/src/Shared/CodeRequest.php
+++ b/src/Shared/CodeRequest.php
@@ -8,7 +8,7 @@ namespace PhpCfdi\SatWsDescargaMasiva\Shared;
  * @method bool isAccepted()
  * @method bool isExhausted()
  * @method bool isMaximumLimitReaded()
- * @method bool isNotFound()
+ * @method bool isEmptyResult()
  * @method bool isDuplicated()
  */
 final class CodeRequest extends OpenEnum
@@ -27,8 +27,8 @@ final class CodeRequest extends OpenEnum
             'message' => 'Tope máximo: Indica que se está superando el tope máximo de CFDI o Metadata',
         ],
         5004 => [
-            'name' => 'NotFound',
-            'message' => 'No se encontró la solicitud',
+            'name' => 'EmptyResult',
+            'message' => 'No se encontró la información: Indica que no generó paquetes por falta de información.',
         ],
         5005 => [
             'name' => 'Duplicated',

--- a/tests/Unit/Services/Verify/VerifyTranslatorTest.php
+++ b/tests/Unit/Services/Verify/VerifyTranslatorTest.php
@@ -32,7 +32,7 @@ class VerifyTranslatorTest extends TestCase
         $this->assertEquals($expectedStatusRequest, $statusRequest->getValue());
         $this->assertTrue($statusRequest->isRejected());
         $this->assertEquals($expectedCodeRequest, $codeRequest->getValue());
-        $this->assertTrue($codeRequest->isNotFound());
+        $this->assertTrue($codeRequest->isEmptyResult());
         $this->assertEquals($expectedNumberCfdis, $result->getNumberCfdis());
         $this->assertEquals($expectedPackagesIds, $result->getPackagesIds());
     }


### PR DESCRIPTION
El método isNotFound creo que da entender "no se encontró la solicitud", en realidad la solicitud si existe pero no generó resultados.