### PR TITLE
Prevent errors on CSV read

### DIFF
--- a/src/PackageReader/MetadataContent.php
+++ b/src/PackageReader/MetadataContent.php
@@ -52,12 +52,12 @@ class MetadataContent
         $onFirstLine = true;
         // process content lines
         foreach ($this->iterator as $data) {
+            if (! is_array($data) || 0 === count($data) | [null] === $data) {
+                continue;
+            }
             if ($onFirstLine) {
                 $onFirstLine = false;
                 $headers = array_map('lcfirst', $data);
-                continue;
-            }
-            if (! is_array($data)) {
                 continue;
             }
 

--- a/src/PackageReader/MetadataContent.php
+++ b/src/PackageReader/MetadataContent.php
@@ -67,6 +67,16 @@ class MetadataContent
 
     public function createMetadataItem(array $headers, array $values): MetadataItem
     {
+        $countValues = count($values);
+        $countHeaders = count($headers);
+        if ($countHeaders > $countValues) {
+            $values = array_merge($values, array_fill($countValues, $countHeaders - $countValues, ''));
+        }
+        if ($countValues > $countHeaders) {
+            for ($i = 1; $i <= $countValues - $countHeaders; $i++) {
+                $headers[] = sprintf('#extra-%02d', $i);
+            }
+        }
         return new MetadataItem(array_combine($headers, $values) ?: []);
     }
 }

--- a/tests/Unit/PackageReader/MetadataContentTest.php
+++ b/tests/Unit/PackageReader/MetadataContentTest.php
@@ -24,4 +24,24 @@ class MetadataContentTest extends TestCase
         ];
         $this->assertSame($expected, $extracted);
     }
+
+    public function testCreateMetadataWithLessValuesThanHeaders(): void
+    {
+        $headers = ['foo', 'bar'];
+        $values = ['x-foo'];
+        $expected = ['foo' => 'x-foo', 'bar' => ''];
+        $reader = MetadataContent::createFromContents('');
+        $metadata = $reader->createMetadataItem($headers, $values);
+        $this->assertSame($expected, $metadata->all());
+    }
+
+    public function testCreateMetadataWithMoreValuesThanHeaders(): void
+    {
+        $headers = ['xee', 'foo'];
+        $values = ['x-xee', 'x-foo', 'x-bar'];
+        $expected = ['xee' => 'x-xee', 'foo' => 'x-foo', '#extra-01' => 'x-bar'];
+        $reader = MetadataContent::createFromContents('');
+        $metadata = $reader->createMetadataItem($headers, $values);
+        $this->assertSame($expected, $metadata->all());
+    }
 }

--- a/tests/Unit/PackageReader/MetadataContentTest.php
+++ b/tests/Unit/PackageReader/MetadataContentTest.php
@@ -25,6 +25,33 @@ class MetadataContentTest extends TestCase
         $this->assertSame($expected, $extracted);
     }
 
+    public function testReadMetadataWithBlankLines(): void
+    {
+        $contents = implode(PHP_EOL, [
+            '', // leading blank line
+            'id~text',
+            '', // before data blank line
+            '1~one',
+            '2~two',
+            '', // inner data blank line
+            '3~three',
+            '', // trailing blank lines
+            '',
+        ]);
+        $reader = MetadataContent::createFromContents($contents);
+        $extracted = [];
+        foreach ($reader->eachItem() as $item) {
+            $extracted[] = $item->all();
+        }
+
+        $expected = [
+            ['id' => '1', 'text' => 'one'],
+            ['id' => '2', 'text' => 'two'],
+            ['id' => '3', 'text' => 'three'],
+        ];
+        $this->assertSame($expected, $extracted);
+    }
+
     public function testCreateMetadataWithLessValuesThanHeaders(): void
     {
         $headers = ['foo', 'bar'];


### PR DESCRIPTION
- If blank lines appears inside CSV content
- If there are more headers than contents
- If there are more contents than headers (create #extra-01, #extra-nn)

This is a proposal for version 0.2.1, if agree with this commit let me change the CHANGELOG before merge.