### PR TITLE
Version 0.2.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,11 +7,11 @@
 /composer.lock       export-ignore
 
 # Do not put this files on a distribution package
-/docs/               export-ignore
 /tests/              export-ignore
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
 /.php_cs.dist        export-ignore
+/.phplint.yml        export-ignore
 /.scrutinizer.yml    export-ignore
 /.travis.yml         export-ignore
 /phpcs.xml.dist      export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /vendor
 /build
 /composer.lock
-.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,18 @@ sudo: false
 php:
   - "7.2"
   - "7.3"
+  - "7.4snapshot"
+
+matrix:
+  allow_failures:
+    - php: "7.4snapshot"
 
 cache:
   - directories:
     - $HOME/.composer
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || true
   - travis_retry composer install --no-interaction --prefer-dist
   - mkdir -p build
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: http://img.shields.io/badge/source-phpcfdi/sat--ws--descarga--masiva-blue?style=flat-square
 [badge-discord]: https://img.shields.io/discord/459860554090283019?logo=discord&style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-ws-descarga-masiva?style=flat-square
-[badge-license]: https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square
+[badge-license]: https://img.shields.io/github/license/phpcfdi/sat-ws-descarga-masiva?style=flat-square
 [badge-build]: https://img.shields.io/travis/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ y recuerda revisar el archivo de tareas pendientes [TODO][] y el [CHANGELOG][].
 
 ## Copyright and License
 
-The phpcfdi/sat-ws-descarga-masiva library is copyright © [PhpCfdi](https://github.com/phpcfdi)
+The `phpcfdi/sat-ws-descarga-masiva` library is copyright © [PhpCfdi](https://www.phpcfdi.com)
 and licensed for use under the MIT License (MIT). Please see [LICENSE][] for more information.
 
 

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,13 @@
         {
             "name": "Carlos C Soto",
             "email": "eclipxe13@gmail.com",
-            "homepage": "https://github.com/phpcfdi/sat-ws-descarga-masiva"
         }
     ],
+    "support": {
+        "source": "https://github.com/phpcfdi/sat-ws-descarga-masiva",
+        "issues": "https://github.com/phpcfdi/sat-ws-descarga-masiva/issues",
+        "chat": "https://discord.gg/aFGYXvX"
+    },
     "require": {
         "php": ">=7.2",
         "ext-openssl": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         },
         {
             "name": "Carlos C Soto",
-            "email": "eclipxe13@gmail.com",
+            "email": "eclipxe13@gmail.com"
         }
     ],
     "support": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,14 @@ In summary, [SemVer](https://semver.org/) can be viewed as ` Breaking . Feature 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
 
+## Version 0.2.3 2019-09-23
+
+- Improve usage of `ResponseInterface->getBody(): StreamInterface` using `__toString()` to retrieve contents at once.
+- Include `docs/` in package, exclude development file `.phplint.yml`.
+- Add PHP 7.4snapshot (allow fail) to Travis CI build matrix.
+- Other minor documentation typos
+ 
+
 ## Version 0.2.2 2019-08-20
 
 - Make sure that when constructing a `DateTime` it fails with an exception.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,12 +1,11 @@
 # phpcfdi/sat-ws-descarga-masiva To Do List
 
-- Mover la dependencia del certificado a phpcfdi/sat-credentials una vez que exista el proyecto
-
 - Mover el script de consumo con credenciales válidas a su propio proyecto dependiente de este.
 
 - Llevar el code coverage a 100% con test unitarios
-    2019-08-09: Current 86% 
-    2019-08-08: Current 84% 
+    2019-08-23: Current 93%
+    2019-08-09: Current 86%
+    2019-08-08: Current 84%
 
 ## Tareas resueltas
 
@@ -51,3 +50,7 @@
 - Verificar que los atributos en QueryTranslator SolicitaDescarga/solicitud son importantes,
   En caso de ser posible, poner los atributos en orden alfabético.
   2019-08-08: Se agregó la verificación de XmlSecLib para garantizar que está firmado correctamente
+
+- Mover la dependencia del certificado a `phpcfdi/sat-credentials` una vez que exista el proyecto
+  2019-08-13: Se agregó la dependencia a `phpcfdi/credentials` y el uso y explotación de certificados
+  y llaves privadas se recarga en esta otra librería.

--- a/tests/WebClient/GuzzleWebClient.php
+++ b/tests/WebClient/GuzzleWebClient.php
@@ -68,8 +68,7 @@ class GuzzleWebClient implements WebClientInterface
         if (null === $response) {
             return new Response(500, '', []);
         }
-        $response->getBody()->rewind();
-        $body = $response->getBody()->getContents();
+        $body = strval($response->getBody());
         $headers = [];
         foreach (array_keys($response->getHeaders()) as $header) {
             $headers[$header] = $response->getHeaderLine($header);


### PR DESCRIPTION
- Improve usage of `ResponseInterface->getBody(): StreamInterface` using `__toString()` to retrieve contents at once.
- Include `docs/` in package, exclude development file `.phplint.yml`.
- Add PHP 7.4snapshot (allow fail) to Travis CI build matrix.
- Other minor documentation typos