### PR TITLE
Version 0.2.5 2020-01-07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,7 @@
 language: php
 
 # php compatibility
-php:
-  - "7.2"
-  - "7.3"
-  - "7.4snapshot"
-
-env:
-  global:
-    - PHP_CS_FIXER_FUTURE_MODE=1
-    - PHP_CS_FIXER_IGNORE_ENV=1
+php: ["7.2", "7.3", "7.4"]
 
 cache:
   - directories:
@@ -23,7 +15,7 @@ script:
   - vendor/bin/php-cs-fixer fix --verbose --dry-run
   - vendor/bin/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit --testdox --verbose
-  - vendor/bin/phpstan.phar analyse --no-progress --verbose --level max src/ tests/
+  - vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/
 
 notifications:
   email:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 PHPCFDI
+Copyright (c) 2019-2020 PHPCFDI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan-shim": "^0.11"
+        "phpstan/phpstan": "^0.11"
     },
     "suggest": {
         "guzzlehttp/guzzle": "To use GuzzleWebClient implementation"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,10 +10,13 @@ In summary, [SemVer](https://semver.org/) can be viewed as ` Breaking . Feature 
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
-## Importante:
+## Version 0.2.5 2020-01-07
 
-- En Travis-CI pasar de `7.4snapshot` a `7.4` cuando se corrija el bug de construcción.
-  <https://travis-ci.community/t/some-extensions-are-missing-in-php-7-4-0-zip-gmp-sodium/6320/9>.
+- Se actualiza el año de licencia a 2020.
+- Se remueve método privado `FielData::readContents(): string` porque ya no está en uso.
+- Se corrige la construcción con PHP 7.4 en Travis.
+- Se cambia la dependencia de `phpstan-shim` a `phpstan`.
+
 
 ## Version 0.2.4 2019-12-06
 

--- a/tests/Scripts/Helpers/FielData.php
+++ b/tests/Scripts/Helpers/FielData.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\SatWsDescargaMasiva\Tests\Scripts\Helpers;
 
 use PhpCfdi\Credentials\Credential;
 use PhpCfdi\SatWsDescargaMasiva\Shared\Fiel;
-use RuntimeException;
 
 class FielData
 {
@@ -50,13 +49,5 @@ class FielData
                 $this->getPassPhrase()
             )
         );
-    }
-
-    private function readContents(string $filename): string
-    {
-        if (! file_exists($filename) || ! is_readable($filename) || is_dir($filename)) {
-            throw new RuntimeException("File $filename does not exists, is not readable or is a directory");
-        }
-        return strval(file_get_contents($filename));
     }
 }


### PR DESCRIPTION
- Se actualiza el año de licencia a 2020.
- Se remueve método privado `FielData::readContents(): string` porque ya no está en uso.
- Se corrige la construcción con PHP 7.4 en Travis.
- Se cambia la dependencia de `phpstan-shim` a `phpstan`.