### PR TITLE
Improve Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
 
 # php compatibility
-php: ["7.3", "7.4"]
+php: ["7.3", "7.4", "nightly"]
+
+matrix:
+  allow_failures:
+    - php: "nightly"
 
 cache:
   - directories:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [discord]: https://discord.gg/aFGYXvX
 [release]: https://github.com/phpcfdi/sat-ws-descarga-masiva/releases
 [license]: https://github.com/phpcfdi/sat-ws-descarga-masiva/blob/master/LICENSE
-[build]: https://travis-ci.org/phpcfdi/sat-ws-descarga-masiva?branch=master
+[build]: https://travis-ci.com/phpcfdi/sat-ws-descarga-masiva?branch=master
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/sat-ws-descarga-masiva/
 [coverage]: https://scrutinizer-ci.com/g/phpcfdi/sat-ws-descarga-masiva/code-structure/master/code-coverage/src/
 [downloads]: https://packagist.org/packages/phpcfdi/sat-ws-descarga-masiva
@@ -186,7 +186,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-discord]: https://img.shields.io/discord/459860554090283019?logo=discord&style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-ws-descarga-masiva?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/sat-ws-descarga-masiva?style=flat-square
-[badge-build]: https://img.shields.io/travis/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square
+[badge-build]: https://img.shields.io/travis/com/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-ws-descarga-masiva/master?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/sat-ws-descarga-masiva?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 - PHPStan estaba dando un falso positivo al detectar que `DOMElement::$attributes` puede contener `null`.
   Esto es solo cierto para cualquier `DOMNode` pero no para `DOMElement`.
 - Se corrigieron las ligas a Travis-CI.
+- Se agrega a Travis-CI la versión "php: nightly" pero se le permite fallar.
 
 ## Version 0.3.1 2020-06-04
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 
 - PHPStan estaba dando un falso positivo al detectar que `DOMElement::$attributes` puede contener `null`.
   Esto es solo cierto para cualquier `DOMNode` pero no para `DOMElement`.
+- Se corrigieron las ligas a Travis-CI.
 
 ## Version 0.3.1 2020-06-04
 


### PR DESCRIPTION
- Fix links on REAME.md
- Add php: nightly to tests agains latests versions
- Include it on `allow_failures` matrix

This will make travis to build the library agains PHP 8.