### PR TITLE
#24 preg_match pattern

### DIFF
--- a/src/PackageReader/MetadataPackageReader.php
+++ b/src/PackageReader/MetadataPackageReader.php
@@ -23,7 +23,7 @@ class MetadataPackageReader extends AbstractPackageReader
 
     protected function filterEntryFilename(string $filename): bool
     {
-        if (boolval(preg_match('^[^\/\\]+\.txt$', $filename))) {
+        if (boolval(preg_match('^[^\/\\\\]+\.txt$', $filename))) {
             return true;
         }
         return false;

--- a/src/PackageReader/MetadataPackageReader.php
+++ b/src/PackageReader/MetadataPackageReader.php
@@ -23,7 +23,7 @@ class MetadataPackageReader extends AbstractPackageReader
 
     protected function filterEntryFilename(string $filename): bool
     {
-        if (boolval(preg_match('/^[\w\-]{36}_[\d]+\.txt$/i', $filename))) {
+        if (boolval(preg_match('/^[\w\-]{36}(_|-)[\d]+\.txt$/i', $filename))) {
             return true;
         }
         return false;

--- a/src/PackageReader/MetadataPackageReader.php
+++ b/src/PackageReader/MetadataPackageReader.php
@@ -23,7 +23,7 @@ class MetadataPackageReader extends AbstractPackageReader
 
     protected function filterEntryFilename(string $filename): bool
     {
-        if (boolval(preg_match('/^[\w\-]{36}(_|-)[\d]+\.txt$/i', $filename))) {
+        if (boolval(preg_match('^[^\/\\]+\.txt$', $filename))) {
             return true;
         }
         return false;

--- a/src/PackageReader/MetadataPackageReader.php
+++ b/src/PackageReader/MetadataPackageReader.php
@@ -23,7 +23,7 @@ class MetadataPackageReader extends AbstractPackageReader
 
     protected function filterEntryFilename(string $filename): bool
     {
-        if (boolval(preg_match('^[^\/\\\\]+\.txt$', $filename))) {
+        if (boolval(preg_match('/^[^\/\\\\]+\.txt$/i', $filename))) {
             return true;
         }
         return false;


### PR DESCRIPTION
Se modifica la expresión regular para tomar en cuenta que los archivos puedan tener como separador el guión bajo.