### PR TITLE
Mejoras en las pruebas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,11 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 
 - PHPStan reporta error de tipo *"Access to an undefined property"* en la clase `MetadataItem`.
   Sin embargo, la clase implementa el método mágico `__get` por lo que la propiedad no necesariamente
-  se debe considerar indefinida. Se corrigió anotando la línea para que fuera ignorada. 
+  se debe considerar indefinida. Se corrigió anotando la línea para que fuera ignorada.
+- Se corrigen las pruebas porque ahora PHPStan entiende el control de flujo de PHPUnit y eso rompía
+  la integración contínua con Travis-CI.
+- Se mejora el flujo de la prueba `ServiceConsumerTest::testRunRequestWithWebClientException`.
+- Se corrige en las pruebas el uso de `current()` pues puede devolver `false` y se espera `string`.
 
 ## Version 0.4.0 2020-10-14
 

--- a/tests/Unit/Internal/ServiceConsumerTest.php
+++ b/tests/Unit/Internal/ServiceConsumerTest.php
@@ -100,16 +100,14 @@ class ServiceConsumerTest extends TestCase
         $webClient->expects($this->once())->method('fireResponse')->with($response);
 
         $consumer = new ServiceConsumer();
-        $thrownException = null;
+        // use try catch and not excpectException because must check WebClientException contains expected response
         try {
             $consumer->runRequest($webClient, $request);
         } catch (WebClientException $webClientException) {
-            $thrownException = $webClientException;
+            $this->assertSame($response, $webClientException->getResponse());
+            return;
         }
-        if (null === $thrownException) {
-            $this->fail('The WebClientException was not thrown');
-        }
-        $this->assertSame($response, $thrownException->getResponse());
+        $this->fail('The WebClientException was not thrown');
     }
 
     public function testCheckErrorWithFault(): void

--- a/tests/Unit/PackageReader/MetadataItemTest.php
+++ b/tests/Unit/PackageReader/MetadataItemTest.php
@@ -35,7 +35,7 @@ class MetadataItemTest extends TestCase
 
         $zipFilename = $this->filePath('zip/metadata.zip');
         $packageReader = MetadataPackageReader::createFromFile($zipFilename);
-        $extracted = current(iterator_to_array($packageReader->fileContents()));
+        $extracted = (string) current(iterator_to_array($packageReader->fileContents()));
 
         // normalize line endings
         $expectedContent = str_replace("\r\n", "\n", $expectedContent);


### PR DESCRIPTION
- Se corrigen las pruebas porque ahora PHPStan entiende el control de flujo de PHPUnit y eso rompía la integración contínua con Travis-CI. (by @gueroverde).
- Se mejora el flujo de la prueba `ServiceConsumerTest::testRunRequestWithWebClientException`.
- Se corrige en las pruebas el uso de `current()` pues puede devolver `false` y se espera `string`.