### PR TITLE
Fix Travis-CI build

### DIFF
--- a/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
+++ b/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
@@ -23,7 +23,7 @@ class FielRequestBuilderTest extends TestCase
     public function testFielRequestImplementsRequestBuilderInterface(): void
     {
         $expected = RequestBuilderInterface::class;
-        $interfaces = class_implements(FielRequestBuilder::class);
+        $interfaces = class_implements(FielRequestBuilder::class) ?: [];
         $this->assertContains($expected, $interfaces);
     }
 


### PR DESCRIPTION
PHPStan detects that class_implements can return false and it would be a type error on the following code. This PR fixes that issue and build would be green again.