### PR TITLE
Refactorización eliminación de método innecesario

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,8 +15,8 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
 ## Sin liberar 
-- Se elimina método innecesario FielRequestBuilder::nospaces() y se usa en su lugar el método Helper::nospaces().
-- Se agrega el comentario int<0, max> en la clase MetadataContent para evitar error en phpstan.
+- Se elimina método innecesario `FielRequestBuilder::nospaces()` y se usa en su lugar el método `Helper::nospaces()`.
+- Se agrega el comentario `int<0, max>` en la clase `MetadataContent` para evitar error en phpstan.
 
 ## Version 0.4.2 2020-11-25
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `master-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Sin liberar 
+- Se elimina método innecesario FielRequestBuilder::nospaces() y se usa en su lugar el método Helper::nospaces().
+- Se agrega el comentario int<0, max> en la clase MetadataContent para evitar error en phpstan.
+
 ## Version 0.4.2 2020-11-25
 
 - Se corrige el extractor de UUID de un CFDI, no estaba funcionando correctamente y en algunas

--- a/src/PackageReader/Internal/MetadataContent.php
+++ b/src/PackageReader/Internal/MetadataContent.php
@@ -83,8 +83,10 @@ final class MetadataContent
     {
         $countValues = count($values);
         $countHeaders = count($headers);
+        /** @var int<0, max> $countSub */
+        $countSub = $countHeaders - $countValues;
         if ($countHeaders > $countValues) {
-            $values = array_merge($values, array_fill($countValues, $countHeaders - $countValues, ''));
+            $values = array_merge($values, array_fill($countValues, $countSub, ''));
         }
         if ($countValues > $countHeaders) {
             for ($i = 1; $i <= $countValues - $countHeaders; $i++) {

--- a/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
+++ b/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
@@ -71,7 +71,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
             </s:Envelope>
             EOT;
 
-        return $this->nospaces($xml);
+        return Helpers::nospaces($xml);
     }
 
     public function query(string $start, string $end, string $rfcIssuer, string $rfcReceiver, string $requestType): string
@@ -139,7 +139,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
             </s:Envelope>
             EOT;
 
-        return $this->nospaces($xml);
+        return Helpers::nospaces($xml);
     }
 
     public function verify(string $requestId): string
@@ -166,7 +166,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
             </s:Envelope>
             EOT;
 
-        return $this->nospaces($xml);
+        return Helpers::nospaces($xml);
     }
 
     public function download(string $packageId): string
@@ -193,7 +193,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
             </s:Envelope>
             EOT;
 
-        return $this->nospaces($xml);
+        return Helpers::nospaces($xml);
     }
 
     private static function createXmlSecurityTokenId(): string
@@ -211,7 +211,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
 
     private function createSignature(string $toDigest, string $signedInfoUri = '', string $keyInfo = ''): string
     {
-        $toDigest = $this->nospaces($toDigest);
+        $toDigest = Helpers::nospaces($toDigest);
         $digested = base64_encode(sha1($toDigest, true));
         $signedInfo = $this->createSignedInfoCanonicalExclusive($digested, $signedInfoUri);
         $signatureValue = base64_encode($this->getFiel()->sign($signedInfo, OPENSSL_ALGO_SHA1));
@@ -247,7 +247,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
                 </Reference>
             </SignedInfo>
             EOT;
-        return $this->nospaces($xml);
+        return Helpers::nospaces($xml);
     }
 
     private function createKeyInfoData(): string
@@ -268,10 +268,5 @@ final class FielRequestBuilder implements RequestBuilderInterface
                 </X509Data>
             </KeyInfo>
             EOT;
-    }
-
-    private function nospaces(string $input): string
-    {
-        return preg_replace(['/^\h*/m', '/\h*\r?\n/m'], '', $input) ?? '';
     }
 }


### PR DESCRIPTION
- Se elimina método innecesario FielRequestBuilder::nospaces() y se usa en su lugar el método Helper::nospaces().
- Se agrega el comentario int<0, max> en la clase MetadataContent para evitar error en phpstan.