### PR TITLE
Compatibilización del servicio de solicitud de descargas masivas versión 1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.7.0" installed="3.7.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.4.8" installed="1.4.8" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-zip": "*",
+        "ext-mbstring": "*",
         "phpcfdi/credentials": "^1.1",
         "eclipxe/enum": "^0.2.0",
         "eclipxe/micro-catalog": "^0.1.2"

--- a/composer.json
+++ b/composer.json
@@ -51,24 +51,24 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
-            "tools/php-cs-fixer fix --dry-run --verbose",
-            "tools/phpcs --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php tools/phpcs --colors -sp src/ tests/"
         ],
         "dev:fix-style": [
-            "tools/php-cs-fixer fix --verbose",
-            "tools/phpcbf --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --verbose",
+            "@php tools/phpcbf --colors -sp src/ tests/"
         ],
         "dev:test": [
             "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "tools/phpstan analyse --verbose --no-progress"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php tools/phpstan analyse --no-interaction --no-progress"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
-        "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
+        "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
         "dev:test": "DEV: run @dev:check-style, phpunit and phpstan",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
-## Version 0.4.3 2022-02-18
+## Versión 0.4.3 2022-02-18
 
 - Se elimina método innecesario `FielRequestBuilder::nospaces()` y se usa en su lugar el método `Helper::nospaces()`.
 - Se actualizaron las herramientas de desarrollo y se utiliza `phive` para administrarlas.
@@ -26,14 +26,14 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 - Add SonarCloud integration.
 - Se elimina Scrutinizer CI. Gracias Scrutinizer.
 
-## Version 0.4.2 2020-11-25
+## Versión 0.4.2 2020-11-25
 
 - Se corrige el extractor de UUID de un CFDI, no estaba funcionando correctamente y en algunas
   ocasiones provocaba que se leyera el valor de `CfdiRelacionado@UUID` en lugar del valor correcto
   de `TimbreFiscalDigital@UUID`. Esto solo ocurría cuando en el nodo principal `<Comprobante>` se
   definía el espacio de nombres o la ubicación del esquema de `TimbreFiscalDigital`.
 
-## Version 0.4.1 2020-11-25
+## Versión 0.4.1 2020-11-25
 
 - PHPStan reporta error de tipo *"Access to an undefined property"* en la clase `MetadataItem`.
   Sin embargo, la clase implementa el método mágico `__get` por lo que la propiedad no necesariamente
@@ -43,7 +43,7 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 - Se mejora el flujo de la prueba `ServiceConsumerTest::testRunRequestWithWebClientException`.
 - Se corrige en las pruebas el uso de `current()` pues puede devolver `false` y se espera `string`.
 
-## Version 0.4.0 2020-10-14
+## Versión 0.4.0 2020-10-14
 
 - Guía de actualización de la versión 0.3.2 a la versión 0.4.0: [UPGRADE_0.3_0.4](UPGRADE_0.3_0.4.md)
 - Se agregan [excepciones específicas en la librería](Excepciones.md). Además, cuando se detecta una respuesta
@@ -86,34 +86,34 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
     - Se separan los bloques de ejemplos de uso en cada caso en lugar de usar solo un bloque.
     - Los códigos de servicios cambian de `Services-StatusCode.md` a `CodigosDeServicios`.
 
-## Version 0.3.2 2020-07-28
+## Versión 0.3.2 2020-07-28
 
 - Se corrige el problema de cambio de formato al definir el nombre de los archivos contenidos en
   un paquete de Metadata, el formato anterior era `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee_01.txt` y
   el nuevo es `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-0001.txt`. La corrección se relajó para que
-  admita cualquier nombre de archivo con extensión `.txt` y que esté en el la raíz. Esta es la
+  admita cualquier nombre de archivo con extensión `.txt` y que esté en la raíz. Esta es la
   misma estrategia utilizada en el lector de paquetes de CFDI (issue #23).
 - Se corrige el problema en que dentro de un archivo de Metadata donde puede contener caracteres
   extraños en los campos de *nombre emisor* y *nombre receptor*. La corrección se consideró tomando
   en cuenta que estos campos pueden contener *comillas* `"`, para ello se considera el pipe `|` como
-  delimitador de cadenas. La segunda corrección identifica si el `EOL` es `<CR><LF>` y en ese caso
-  elimina cualquier `<LF>` intermedio (issue #23).
+  delimitador de cadenas. La segunda corrección identifica si el fin de línea `EOL` es `<CR><LF>`
+  y en ese caso elimina cualquier `<LF>` intermedio (issue #23).
 - PHPStan estaba dando un falso positivo al detectar que `DOMElement::$attributes` puede contener `null`.
   Esto es solo cierto para cualquier `DOMNode` pero no para `DOMElement`.
 - Se corrigieron las ligas a Travis-CI.
 - Se agrega a Travis-CI la versión `php: nightly`, pero se le permite fallar.
 
-## Version 0.3.1 2020-06-04
+## Versión 0.3.1 2020-06-04
 
 - Se corrige el problema de que recientemente los archivos ZIP de consultas de CFDI vienen con doble extensión,
   por ejemplo `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.xml.xml`.
 
-## Version 0.3.0 2020-05-01
+## Versión 0.3.0 2020-05-01
 
 - Se actualizan las dependencias `php: >=7.3` y `phpunit: ^9.1`.
 - Se actualiza `php-cs-fixer` para usar `@PHP73Migration`.
 
-## Version 0.2.6 2020-04-11
+## Versión 0.2.6 2020-04-11
 
 - Se actualizan los tests para que usen el RFC `EKU9003173C9`.
 - Se agrega un test para probar qué ocurre al usar un `CSD` en lugar de una `FIEL`.
@@ -122,7 +122,7 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 - Se utiliza `eclipxe/micro-catalog` en lugar de la clase interna `OpenEnum`.
 - Se renombra `Helpers::createUuid` a `Helpers::createXmlSecurityTokenId`.
 
-## Version 0.2.5 2020-01-07
+## Versión 0.2.5 2020-01-07
 
 - Se actualiza el año de licencia a 2020.
 - Se remueve método privado `FielData::readContents(): string` porque ya no está en uso.
@@ -130,10 +130,10 @@ o estás usando una versión cero (por ejemplo `0.18.4`).
 - Se cambia la dependencia de `phpstan-shim` a `phpstan`.
 
 
-## Version 0.2.4 2019-12-06
+## Versión 0.2.4 2019-12-06
 
 - Se agrega la clase `PhpCfdi\SatWsDescargaMasiva\WebClient\GuzzleWebClient` que estaba en testing
-  a el código distribuible, aunque no se agrega la dependencia `guzzlehttp/guzzle`.
+  al código distribuible, aunque no se agrega la dependencia `guzzlehttp/guzzle`.
 - Se documenta el uso de `GuzzleWebClient`.
 - Forzar la dependencia de `phpcfdi/credentials` a `^1.1` para leer llaves privadas en formato DER.
 - Forzar la dependencia de `robrichards/xmlseclibs` a `^3.0.4` por reporte de seguridad `CVE-2019-3465`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,41 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Versión 0.4.4 2022-03-12
+
+Se actualizó el servicio de solicitud de descargas masivas (consulta) a la versión 1.2 del SAT.
+Esta actualización por el momento solo está sobre CFDI regulares, no sobre Retenciones e información de pagos.
+En este último el servicio se encuentra caído.
+
+Al parecer la actualización no se ha completado en el SAT, y ha estado inestable desde 2022-03-14.
+Sin embargo, con esta actualización se compatibliza el servicio con el funcionamiento esperado.
+
+### Cambios en la solicitud
+
+Se elimina el atributo `RfcReceptor` y se agrega el elemento `RfcReceptores/RfcReceptor` para especificar
+el RFC del receptor en la consulta.
+
+### CodEstatus 5006
+
+Se agrega a la documentación de `CodEstatus` (clase `StatusCode`) el código `5006 - Error interno en el proceso`
+que se supone sustituye al código `404 - Error no Controlado` para el servicio de consulta.
+
+### Correcciones
+
+Se agrega el método mágico `MetadataItem::__isset(string $name): bool` que no estaba contemplado.
+
+### Entorno de desarrollo
+
+- En las pruebas de integración, se hacen dos pruebas de solicitud consulta, una para emitidos y otra para recibidos.
+- Se actualizan los archivos de muestra en las comprobaciones unitarias.
+- Se agrega como dependencia la extensión de PHP `mbstring`.
+- Se refactoriza la clase interna `Helpers::nospaces()` para insertar un *Line feed (LF)*.
+  después de la especificación de XML.
+- En las pruebas de integración, se agrega el método `ConsumeServiceTestCase::createWebClient()`
+  que devuelve un objeto `GuzzleHttp\Client` configurado correctamente con *timeouts*.
+- Se actualizan las herramientas del entorno de desarrollo.
+- CI: Se usan las rutas establecidas en el archivo de configuración de `phpcs`.
+
 ## Versión 0.4.3 2022-02-18
 
 - Se elimina método innecesario `FielRequestBuilder::nospaces()` y se usa en su lugar el método `Helper::nospaces()`.

--- a/docs/CodigosDeServicios.md
+++ b/docs/CodigosDeServicios.md
@@ -27,7 +27,7 @@ Ambos valores se pueden obtener con el objeto `StatusCode` que contiene las prop
 Las respuestas de los servivios cuentan con la propiedad `getStatusCode(): StatusCode`, por ejemplo `VerifyResult::getStatusCode()`.
 
 | Servicio          | Code | Descripción                                                                             |
-| ----------------- | ---- | --------------------------------------------------------------------------------------- |
+|-------------------|------|-----------------------------------------------------------------------------------------|
 | All               | 300  | Usuario no válido                                                                       |
 | All               | 301  | XML mal formado                                                                         |
 | All               | 302  | Sello mal formado                                                                       |
@@ -39,7 +39,8 @@ Las respuestas de los servivios cuentan con la propiedad `getStatusCode(): Statu
 | Query             | 5002 | Se agotó las solicitudes de por vida: Máximo para solicitudes con los mismos parámetros |
 | Verify & download | 5004 | No se encontró la solicitud                                                             |
 | Query             | 5005 | Solicitud duplicada: Si existe una solicitud vigente con los mismos parámetros          |
-| Query & download  | 404  | Error no controlado: Reintentar más tarde la petición                                   |
+| Query             | 5006 | Error interno en el proceso                                                             |
+| Download          | 404  | Error no controlado: Reintentar más tarde la petición                                   |
 
 ## Acerca de `CodigoEstadoSolicitud`
 

--- a/docs/CodigosDeServicios.md
+++ b/docs/CodigosDeServicios.md
@@ -57,7 +57,7 @@ Este objeto también permite la comprobación por *nombre clave*, por lo que pue
 `CodeRequest::isEmptyResult()` para conocer si se encuentra en el estado `5004: No se encontró la solicitud`.  
 
 | Code | Name               | Descripción                                                                             |
-| ---- | ------------------ | --------------------------------------------------------------------------------------- |
+|------|--------------------|-----------------------------------------------------------------------------------------|
 | 5000 | Accepted           | Solicitud recibida con éxito                                                            |
 | 5002 | Exhausted          | Se agotó las solicitudes de por vida: Máximo para solicitudes con los mismos parámetros |
 | 5003 | MaximumLimitReaded | Tope máximo: Indica que se está superando el tope máximo de CFDI o Metadata             |
@@ -77,12 +77,12 @@ y se puede obtener con el método `StatusRequest::getMessage(): string`.
 Este objeto también permite la comprobación por *nombre clave*, por lo que puedes usar por ejemplo
 `StatusRequest::isExpired()` para conocer si se encuentra en el estado `6: Vencida`.  
 
-| Code | Name         | Descripción  |
-| ---- | ------------ | ------------ |
-| 1    | Accepted     | Aceptada     |
-| 2    | InProgress   | En proceso   |
-| 3    | Finished     | Terminada    |
-| 4    | Failure      | Error        |
-| 5    | Rejected     | Rechazada    |
-| 6    | Expired      | Vencida      |
+| Code | Name       | Descripción |
+|------|------------|-------------|
+| 1    | Accepted   | Aceptada    |
+| 2    | InProgress | En proceso  |
+| 3    | Finished   | Terminada   |
+| 4    | Failure    | Error       |
+| 5    | Rejected   | Rechazada   |
+| 6    | Expired    | Vencida     |
 

--- a/src/Internal/Helpers.php
+++ b/src/Internal/Helpers.php
@@ -14,7 +14,18 @@ class Helpers
 {
     public static function nospaces(string $input): string
     {
-        return preg_replace(['/^\h*/m', '/\h*\r?\n/m'], '', $input) ?? '';
+        return preg_replace(
+            [
+                '/^\h*/m',      // A: remove horizontal spaces at beginning
+                '/\h*\r?\n/m',  // B: remove horizontal spaces + optional CR + LF
+                '/\?></',       // C: xml definition on its own line
+            ], [
+                '',             // A: remove
+                '',             // B: remove
+                "?>\n<",        // C: insert LF
+            ],
+            $input
+        ) ?? '';
     }
 
     public static function cleanPemContents(string $pemContents): string

--- a/src/Internal/Helpers.php
+++ b/src/Internal/Helpers.php
@@ -19,7 +19,8 @@ class Helpers
                 '/^\h*/m',      // A: remove horizontal spaces at beginning
                 '/\h*\r?\n/m',  // B: remove horizontal spaces + optional CR + LF
                 '/\?></',       // C: xml definition on its own line
-            ], [
+            ],
+            [
                 '',             // A: remove
                 '',             // B: remove
                 "?>\n<",        // C: insert LF

--- a/src/PackageReader/MetadataItem.php
+++ b/src/PackageReader/MetadataItem.php
@@ -44,6 +44,11 @@ final class MetadataItem implements JsonSerializable
         return $this->get($name);
     }
 
+    public function __isset(string $name): bool
+    {
+        return isset($this->data[$name]);
+    }
+
     /** @return array<string, string> */
     public function all(): array
     {

--- a/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
+++ b/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
@@ -118,10 +118,15 @@ final class FielRequestBuilder implements RequestBuilderInterface
             array_keys($solicitudAttributes),
             $solicitudAttributes,
         ));
+        $xmlRfcReceived = ($rfcSigner === $rfcReceiver)
+            ? '<des:RfcRecibidos><des:RfcRecibido></des:RfcRecibido></des:RfcRecibidos>'
+            : '';
 
         $toDigestXml = <<<EOT
             <des:SolicitaDescarga xmlns:des="http://DescargaMasivaTerceros.sat.gob.mx">
-                <des:solicitud ${solicitudAttributesAsText}></des:solicitud>
+                <des:solicitud ${solicitudAttributesAsText}>
+                    {$xmlRfcReceived}
+                </des:solicitud>
             </des:SolicitaDescarga>
             EOT;
         $signatureData = $this->createSignature($toDigestXml);
@@ -132,6 +137,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
                 <s:Body>
                     <des:SolicitaDescarga>
                         <des:solicitud ${solicitudAttributesAsText}>
+                            {$xmlRfcReceived}
                             ${signatureData}
                         </des:solicitud>
                     </des:SolicitaDescarga>

--- a/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
+++ b/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
@@ -107,7 +107,6 @@ final class FielRequestBuilder implements RequestBuilderInterface
             'FechaFinal' => $end,
             'TipoSolicitud' => $requestType,
             'RfcEmisor' => $rfcIssuer,
-            'RfcReceptor' => $rfcReceiver,
         ]);
         ksort($solicitudAttributes);
 
@@ -118,14 +117,15 @@ final class FielRequestBuilder implements RequestBuilderInterface
             array_keys($solicitudAttributes),
             $solicitudAttributes,
         ));
-        $xmlRfcReceived = ($rfcSigner === $rfcReceiver)
-            ? '<des:RfcRecibidos><des:RfcRecibido></des:RfcRecibido></des:RfcRecibidos>'
-            : '';
+        $xmlRfcReceived = '';
+        if ('' !== $rfcReceiver) {
+            $xmlRfcReceived = "<des:RfcRecibidos><des:RfcRecibido>${rfcReceiver}</des:RfcRecibido></des:RfcRecibidos>";
+        }
 
         $toDigestXml = <<<EOT
             <des:SolicitaDescarga xmlns:des="http://DescargaMasivaTerceros.sat.gob.mx">
                 <des:solicitud ${solicitudAttributesAsText}>
-                    {$xmlRfcReceived}
+                    ${xmlRfcReceived}
                 </des:solicitud>
             </des:SolicitaDescarga>
             EOT;
@@ -137,7 +137,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
                 <s:Body>
                     <des:SolicitaDescarga>
                         <des:solicitud ${solicitudAttributesAsText}>
-                            {$xmlRfcReceived}
+                            ${xmlRfcReceived}
                             ${signatureData}
                         </des:solicitud>
                     </des:SolicitaDescarga>

--- a/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
+++ b/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
@@ -119,7 +119,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
         ));
         $xmlRfcReceived = '';
         if ('' !== $rfcReceiver) {
-            $xmlRfcReceived = "<des:RfcRecibidos><des:RfcRecibido>${rfcReceiver}</des:RfcRecibido></des:RfcRecibidos>";
+            $xmlRfcReceived = "<des:RfcReceptores><des:RfcReceptor>${rfcReceiver}</des:RfcReceptor></des:RfcReceptores>";
         }
 
         $toDigestXml = <<<EOT

--- a/src/Shared/CodeRequest.php
+++ b/src/Shared/CodeRequest.php
@@ -15,6 +15,7 @@ use JsonSerializable;
  * @method bool isMaximumLimitReaded()
  * @method bool isEmptyResult()
  * @method bool isDuplicated()
+ * @method bool isWsError()
  * @method string getMessage() Contains the known message in spanish
  * @method string getName() Contains the internal name
  */
@@ -40,6 +41,10 @@ final class CodeRequest extends MicroCatalog implements JsonSerializable
         5005 => [
             'name' => 'Duplicated',
             'message' => 'Solicitud duplicada: Si existe una solicitud vigente con los mismos parámetros',
+        ],
+        5006 => [
+            'name' => 'WsError',
+            'message' => 'Error interno en el proceso',
         ],
     ];
 

--- a/src/Shared/CodeRequest.php
+++ b/src/Shared/CodeRequest.php
@@ -15,7 +15,6 @@ use JsonSerializable;
  * @method bool isMaximumLimitReaded()
  * @method bool isEmptyResult()
  * @method bool isDuplicated()
- * @method bool isWsError()
  * @method string getMessage() Contains the known message in spanish
  * @method string getName() Contains the internal name
  */
@@ -41,10 +40,6 @@ final class CodeRequest extends MicroCatalog implements JsonSerializable
         5005 => [
             'name' => 'Duplicated',
             'message' => 'Solicitud duplicada: Si existe una solicitud vigente con los mismos parámetros',
-        ],
-        5006 => [
-            'name' => 'WsError',
-            'message' => 'Error interno en el proceso',
         ],
     ];
 

--- a/tests/Integration/ConsumeCfdiServicesUsingFakeFielTest.php
+++ b/tests/Integration/ConsumeCfdiServicesUsingFakeFielTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace PhpCfdi\SatWsDescargaMasiva\Tests\Integration;
 
 use PhpCfdi\SatWsDescargaMasiva\Service;
-use PhpCfdi\SatWsDescargaMasiva\WebClient\GuzzleWebClient;
 
 final class ConsumeCfdiServicesUsingFakeFielTest extends ConsumeServiceTestCase
 {
     protected function createService(): Service
     {
         $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
-        $webclient = new GuzzleWebClient();
-        return new Service($requestBuilder, $webclient);
+        $webClient = $this->createWebClient();
+        return new Service($requestBuilder, $webClient);
     }
 }

--- a/tests/Integration/ConsumeRetencionesServicesUsingFakeFielTest.php
+++ b/tests/Integration/ConsumeRetencionesServicesUsingFakeFielTest.php
@@ -6,14 +6,13 @@ namespace PhpCfdi\SatWsDescargaMasiva\Tests\Integration;
 
 use PhpCfdi\SatWsDescargaMasiva\Service;
 use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceEndpoints;
-use PhpCfdi\SatWsDescargaMasiva\WebClient\GuzzleWebClient;
 
 final class ConsumeRetencionesServicesUsingFakeFielTest extends ConsumeServiceTestCase
 {
     protected function createService(): Service
     {
         $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
-        $webclient = new GuzzleWebClient();
-        return new Service($requestBuilder, $webclient, null, ServiceEndpoints::retenciones());
+        $webClient = $this->createWebClient();
+        return new Service($requestBuilder, $webClient, null, ServiceEndpoints::retenciones());
     }
 }

--- a/tests/Integration/ConsumeServiceTestCase.php
+++ b/tests/Integration/ConsumeServiceTestCase.php
@@ -23,8 +23,8 @@ abstract class ConsumeServiceTestCase extends TestCase
     protected function createWebClient(): WebClientInterface
     {
         $guzzleClient = new GuzzleClient([
-            RequestOptions::CONNECT_TIMEOUT => 2,
-            RequestOptions::TIMEOUT => 20,
+            RequestOptions::CONNECT_TIMEOUT => 5,
+            RequestOptions::TIMEOUT => 30,
         ]);
         return new GuzzleWebClient($guzzleClient);
     }

--- a/tests/Integration/ConsumeServiceTestCase.php
+++ b/tests/Integration/ConsumeServiceTestCase.php
@@ -34,7 +34,7 @@ abstract class ConsumeServiceTestCase extends TestCase
         $this->assertSame(
             305,
             $result->getStatus()->getCode(),
-            'Expected to recieve a 305 - Certificado Inválido from SAT since FIEL is for testing'
+            'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
         );
     }
 
@@ -47,7 +47,7 @@ abstract class ConsumeServiceTestCase extends TestCase
         $this->assertSame(
             305,
             $result->getStatus()->getCode(),
-            'Expected to recieve a 305 - Certificado Inválido from SAT since FIEL is for testing'
+            'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
         );
     }
 
@@ -60,7 +60,7 @@ abstract class ConsumeServiceTestCase extends TestCase
         $this->assertSame(
             305,
             $result->getStatus()->getCode(),
-            'Expected to recieve a 305 - Certificado Inválido from SAT since FIEL is for testing'
+            'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
         );
     }
 }

--- a/tests/Integration/ConsumeServiceTestCase.php
+++ b/tests/Integration/ConsumeServiceTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatWsDescargaMasiva\Tests\Integration;
 
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\RequestOptions;
 use PhpCfdi\SatWsDescargaMasiva\Service;
 use PhpCfdi\SatWsDescargaMasiva\Services\Query\QueryParameters;
 use PhpCfdi\SatWsDescargaMasiva\Shared\DateTime;
@@ -11,10 +13,21 @@ use PhpCfdi\SatWsDescargaMasiva\Shared\DateTimePeriod;
 use PhpCfdi\SatWsDescargaMasiva\Shared\DownloadType;
 use PhpCfdi\SatWsDescargaMasiva\Shared\RequestType;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use PhpCfdi\SatWsDescargaMasiva\WebClient\GuzzleWebClient;
+use PhpCfdi\SatWsDescargaMasiva\WebClient\WebClientInterface;
 
 abstract class ConsumeServiceTestCase extends TestCase
 {
     abstract protected function createService(): Service;
+
+    protected function createWebClient(): WebClientInterface
+    {
+        $guzzleClient = new GuzzleClient([
+            RequestOptions::CONNECT_TIMEOUT => 1,
+            RequestOptions::TIMEOUT => 10,
+        ]);
+        return new GuzzleWebClient($guzzleClient);
+    }
 
     public function testAuthentication(): void
     {

--- a/tests/Integration/ConsumeServiceTestCase.php
+++ b/tests/Integration/ConsumeServiceTestCase.php
@@ -36,7 +36,22 @@ abstract class ConsumeServiceTestCase extends TestCase
         $this->assertTrue($token->isValid());
     }
 
-    public function testQuery(): void
+    public function testQueryIssued(): void
+    {
+        $service = $this->createService();
+
+        $dateTimePeriod = DateTimePeriod::create(DateTime::create('2019-01-01 00:00:00'), DateTime::create('2019-01-01 00:04:00'));
+        $parameters = QueryParameters::create($dateTimePeriod, DownloadType::issued(), RequestType::cfdi());
+
+        $result = $service->query($parameters);
+        $this->assertSame(
+            305,
+            $result->getStatus()->getCode(),
+            'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
+        );
+    }
+
+    public function testQueryReceived(): void
     {
         $service = $this->createService();
 

--- a/tests/Integration/ConsumeServiceTestCase.php
+++ b/tests/Integration/ConsumeServiceTestCase.php
@@ -23,8 +23,8 @@ abstract class ConsumeServiceTestCase extends TestCase
     protected function createWebClient(): WebClientInterface
     {
         $guzzleClient = new GuzzleClient([
-            RequestOptions::CONNECT_TIMEOUT => 1,
-            RequestOptions::TIMEOUT => 10,
+            RequestOptions::CONNECT_TIMEOUT => 2,
+            RequestOptions::TIMEOUT => 20,
         ]);
         return new GuzzleWebClient($guzzleClient);
     }

--- a/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
+++ b/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
@@ -79,7 +79,7 @@ class FielRequestBuilderTest extends TestCase
         return $matches['id'] ?? '';
     }
 
-    public function testQuery(): void
+    public function testQueryReceived(): void
     {
         $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
         $start = '2019-01-01T00:00:00';
@@ -90,7 +90,27 @@ class FielRequestBuilderTest extends TestCase
         $requestBody = $requestBuilder->query($start, $end, $rfcIssuer, $rfcReceiver, $requestType);
 
         $this->assertSame(
-            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request.xml'))),
+            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-received.xml'))),
+            $this->xmlFormat($requestBody)
+        );
+
+        $xmlSecVerification = (new EnvelopSignatureVerifier())
+            ->verify($requestBody, 'http://DescargaMasivaTerceros.sat.gob.mx', 'SolicitaDescarga');
+        $this->assertTrue($xmlSecVerification, 'The signature cannot be verified using XMLSecLibs');
+    }
+
+    public function testQueryIssued(): void
+    {
+        $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
+        $start = '2019-01-01T00:00:00';
+        $end = '2019-01-01T00:04:00';
+        $rfcIssuer = $requestBuilder->getFiel()->getRfc();
+        $rfcReceiver = '';
+        $requestType = 'CFDI';
+        $requestBody = $requestBuilder->query($start, $end, $rfcIssuer, $rfcReceiver, $requestType);
+
+        $this->assertSame(
+            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-issued.xml'))),
             $this->xmlFormat($requestBody)
         );
 

--- a/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
+++ b/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
@@ -85,7 +85,7 @@ class FielRequestBuilderTest extends TestCase
         $start = '2019-01-01T00:00:00';
         $end = '2019-01-01T00:04:00';
         $rfcIssuer = '';
-        $rfcReceiver = $requestBuilder->getFiel()->getRfc();
+        $rfcReceiver = '*'; // same as signer
         $requestType = 'CFDI';
         $requestBody = $requestBuilder->query($start, $end, $rfcIssuer, $rfcReceiver, $requestType);
 
@@ -104,7 +104,7 @@ class FielRequestBuilderTest extends TestCase
         $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
         $start = '2019-01-01T00:00:00';
         $end = '2019-01-01T00:04:00';
-        $rfcIssuer = $requestBuilder->getFiel()->getRfc();
+        $rfcIssuer = '*'; // same as signer
         $rfcReceiver = '';
         $requestType = 'CFDI';
         $requestBody = $requestBuilder->query($start, $end, $rfcIssuer, $rfcReceiver, $requestType);

--- a/tests/Unit/Services/Query/QueryTranslatorTest.php
+++ b/tests/Unit/Services/Query/QueryTranslatorTest.php
@@ -44,7 +44,7 @@ class QueryTranslatorTest extends TestCase
 
         $requestBody = $translator->createSoapRequest($requestBuilder, $query);
         $this->assertSame(
-            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request.xml'))),
+            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-received.xml'))),
             $this->xmlFormat($requestBody)
         );
     }

--- a/tests/_files/query/request-issued.xml
+++ b/tests/_files/query/request-issued.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:des="http://DescargaMasivaTerceros.sat.gob.mx" xmlns:xd="http://www.w3.org/2000/09/xmldsig#">
+  <s:Header/>
+  <s:Body>
+    <des:SolicitaDescarga>
+      <des:solicitud FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcEmisor="EKU9003173C9" RfcSolicitante="EKU9003173C9" TipoSolicitud="CFDI">
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <SignedInfo>
+            <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+            <Reference URI="">
+              <Transforms>
+                <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+              </Transforms>
+              <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+              <DigestValue>/YlxNcMVGC0/BxfUu2f/xvcZl2M=</DigestValue>
+            </Reference>
+          </SignedInfo>
+          <SignatureValue>ZdvBhn+fiuezccR9Vo7Qf2P+y2DniVQYy4+CItyPSSS6VC3uxjMpvQ4qITGBl641HbJ7va/kUGGZ9WtD1ZN1ER7vaRJ168NYFQGGvZLFb+VeU439Dn8/FVeIuLky1SSm3fFc7UE/YUQER+k5Sl+D7pOlITjVlCnSXMAnv20oZ13YviPrTSgRzHJkUGENDhaUTNVAE5qagIv77euaY44NYb8n4kq86WccePnSCxkTSUibA4NDodtLCw+5ma7dfhDQEkbCTmIU09yMXbnnql0cKpbxZmh7l0nKR4ajc8SS9iGjmdng/30RUnmWRcKz89FdP0aJZBfOjQ84qLiXbgOOVg==</SignatureValue>
+          <KeyInfo>
+            <X509Data>
+              <X509IssuerSerial>
+                <X509IssuerName>CN=AC UAT,O=SERVICIO DE ADMINISTRACION TRIBUTARIA,OU=SAT-IES Authority,emailAddress=oscar.martinez@sat.gob.mx,street=3ra cerrada de cadiz,postalCode=06370,C=MX,ST=CIUDAD DE MEXICO,L=COYOACAN,x500UniqueIdentifier=2.5.4.45,unstructuredName=responsable: ACDMA-SAT</X509IssuerName>
+                <X509SerialNumber>292233162870206001759766198444326234574038511927</X509SerialNumber>
+              </X509IssuerSerial>
+              <X509Certificate>MIIGBDCCA+ygAwIBAgIUMzAwMDEwMDAwMDA0MDAwMDI0MTcwDQYJKoZIhvcNAQELBQAwggErMQ8wDQYDVQQDDAZBQyBVQVQxLjAsBgNVBAoMJVNFUlZJQ0lPIERFIEFETUlOSVNUUkFDSU9OIFRSSUJVVEFSSUExGjAYBgNVBAsMEVNBVC1JRVMgQXV0aG9yaXR5MSgwJgYJKoZIhvcNAQkBFhlvc2Nhci5tYXJ0aW5lekBzYXQuZ29iLm14MR0wGwYDVQQJDBQzcmEgY2VycmFkYSBkZSBjYWRpejEOMAwGA1UEEQwFMDYzNzAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBDSVVEQUQgREUgTUVYSUNPMREwDwYDVQQHDAhDT1lPQUNBTjERMA8GA1UELRMIMi41LjQuNDUxJTAjBgkqhkiG9w0BCQITFnJlc3BvbnNhYmxlOiBBQ0RNQS1TQVQwHhcNMTkwNjE0MjEwNTE1WhcNMjMwNjEzMjEwNTE1WjCB+TEnMCUGA1UEAxMeRVNDVUVMQSBLRU1QRVIgVVJHQVRFIFNBIERFIENWMScwJQYDVQQpEx5FU0NVRUxBIEtFTVBFUiBVUkdBVEUgU0EgREUgQ1YxJzAlBgNVBAoTHkVTQ1VFTEEgS0VNUEVSIFVSR0FURSBTQSBERSBDVjELMAkGA1UEBhMCTVgxKDAmBgkqhkiG9w0BCQEWGVNBVHBydWViYXNAcHJ1ZWJhcy5nb2IubXgxJTAjBgNVBC0THEVLVTkwMDMxNzNDOSAvIFhJUUI4OTExMTZRRTQxHjAcBgNVBAUTFSAvIFhJUUI4OTExMTZNR1JNWlIwNTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIOGnb6RqDyBhK3RDspzJCf5m4gx+lkCzQTvNEphr2GfZ3XyFHDnMeP4+IPz8XdZzQ8WSjd7JeOr5ef/9omLp4Xd6PCh83WmiTZniNPluctYs6WGDGcm/GCAlp4iIyunXX5TJvMAje8Qv8LIm+EmitE/5+OcfPLhDQA/9D34L3D8adoIuUg8UyjK3M8dj62hAkBRDUF/0Z4zPhAPX/BER7lEdZRcDrTo1M0eq8SM09+Q7ItXkMYIBf9Q3JDHfpOnD4JbAJ4dK60ZkUQI0xo+G6is4EAXv02liSRCIfEvlJrZHwGZOUaRccfj2fhRLob90Jbml4NKCURGboijoIuhTiMCAwEAAaNPME0wDAYDVR0TAQH/BAIwADALBgNVHQ8EBAMCA9gwEQYJYIZIAYb4QgEBBAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMEBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAgEAr9uInaTMf6UqST5xpEonsbOeqdnyQsG1ZiYLKw7lnjMjkYkrenManFXkpxHUeWw8Y/4y48iNcmrs1AH+Gd7ZdOJ3XIqIEy0C/SM4GemRx+YMjfsif24dxTN1fD8cU86W1Y56e3rDfgsR9yT/sGmxqvkUN3sQElyD2+qhUZUydK7i03bWIG5fyzGIi15YBhzE6ALuX8po2coUlwQV830zRBPGDkcomejsfKPjYKQ+yzUtwO+8Klr1PUHmdlaG7Gv4llWLNvKm21qAgxjMkiKHLp1Cr66W1ahks8I8VqsLarSKDzGf42VstQpO0hLV1cWXk920nl+n4htYgE7KDQwpioZXFeXCd9KiZcEREn/gvHi6nq6awPJS7k6hBPFEAtbmzwykQ30MNdtHwUXRKAf1yru9VYGIs38ElZyU8C6JJ0MPx/f/N56yHYOYKtYD++STWgXjHD0c/RPV5j1nhjPFhRMHZAuxOwQxky28MQak+pd7OF5cDJiGYfDQZ7G+riGkhodIGS+jmexWQn0tpoZt8U+Ay7L8P7fdqcV9P58AMz4Eie3VrPs2LfpbhNpD/26AvgbkE4Iz4HAOdW9AH1im3Ae8+nWuICnbWcmExqcRqykM1U7MXkOV23L3jtdvDKcP+uCudwL+9Iit6K5pCGvqw7e/uCK0/OyhtyxgA0LDS2A=</X509Certificate>
+            </X509Data>
+          </KeyInfo>
+        </Signature>
+      </des:solicitud>
+    </des:SolicitaDescarga>
+  </s:Body>
+</s:Envelope>

--- a/tests/_files/query/request-received.xml
+++ b/tests/_files/query/request-received.xml
@@ -3,8 +3,8 @@
   <s:Header/>
   <s:Body>
     <des:SolicitaDescarga>
-      <des:solicitud FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcReceptor="EKU9003173C9" RfcSolicitante="EKU9003173C9" TipoSolicitud="CFDI">
-        <des:RfcRecibidos><des:RfcRecibido></des:RfcRecibido></des:RfcRecibidos>
+      <des:solicitud FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcSolicitante="EKU9003173C9" TipoSolicitud="CFDI">
+        <des:RfcRecibidos><des:RfcRecibido>EKU9003173C9</des:RfcRecibido></des:RfcRecibidos>
         <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
           <SignedInfo>
             <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -14,10 +14,10 @@
                 <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
               </Transforms>
               <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-              <DigestValue>zl5htEEYn41pTg+bb2wszUpJHhI=</DigestValue>
+              <DigestValue>UCLUy9DlqZ3gGXY76XEJHa/tnLE=</DigestValue>
             </Reference>
           </SignedInfo>
-          <SignatureValue>KCxrZ59qrtPYGHZWNCcENJM2gO2fNYMh3csf9MXuck6v3p0PU5k8oDHn1LHCZh/RdX/MaZu6bR/yk5h2Wy+11ZEa/U5ELm34iCNVvHVxeq3baBqdLGEjnWdApD00Lb1jr5sMeEtJGvbC+JUVyc57CEgHYCRAFGIV/kK654YqkIa6z/8NAQDEWDSDq9HPYHqu+RRxeAbDSbWpndzDvI91AfUc5fMwWaq7tTvh9sIJS6aCXmS0BlU/uDb6NkWHF46DFR9Pu2Q0qhNnmU1REATQLv5cDiSNesbtUCaHmCyLBsFGnb46Jc8YzrxHXIzRc4uVYdemG2XI5LqTwB0Qwp01zA==</SignatureValue>
+          <SignatureValue>HkYlLZekMoaUBzUvzPB4zxr78DQeC0jcnfMmmALPgNhomVvhf/vhBg67bXBtYGsaFAgyo4Q/J0Fs2kc+BAmYOFmdahCTV0TKVvqYi1MgsRpiMYGrU0MTF35B2ndYS7AK+IfmeRHe6iEoOHKJoP0Xy4ikcSxdpwAl+Myo+WbAZCzFsBjFqGsvknGDAWMixSE0RIwKtpnG8TOS3njvyHm/qwxot3bnKSTj3tHpGbj/2s2yEw8tozLcvL1/DxbSmNmWxWKh6FblYWRt2LI7GMqOH+gzJtxz5XbbDxkzh529qXmon3Zn5i0ZoGkxS3eutsWWbI0kf00sHLY7qh8ydLjtPA==</SignatureValue>
           <KeyInfo>
             <X509Data>
               <X509IssuerSerial>

--- a/tests/_files/query/request-received.xml
+++ b/tests/_files/query/request-received.xml
@@ -4,6 +4,7 @@
   <s:Body>
     <des:SolicitaDescarga>
       <des:solicitud FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcReceptor="EKU9003173C9" RfcSolicitante="EKU9003173C9" TipoSolicitud="CFDI">
+        <des:RfcRecibidos><des:RfcRecibido></des:RfcRecibido></des:RfcRecibidos>
         <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
           <SignedInfo>
             <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -13,10 +14,10 @@
                 <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
               </Transforms>
               <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-              <DigestValue>kJHoUsUmsDAYPRuTOumOjXan01Y=</DigestValue>
+              <DigestValue>zl5htEEYn41pTg+bb2wszUpJHhI=</DigestValue>
             </Reference>
           </SignedInfo>
-          <SignatureValue>PqoLaAsWXey9PiImjWCEYC1PoXyfrlErEK5bF9yyO5d08PVMi2UMXODkzpOGSPz8RiYxnSJBs2M+NTMNl/VLxn+A01Oj1cdvZ1oV249XAZrI981CgYhVsG70W7XYD4Z4VCZmgYivymneBR/GLKaZpKVNm0MQMtsBcycBCx+XDF3e9DIxHFNS8zrgBkoW8otfPUX2fC4DVwonMdxcDq+3mEvyGlwehxjUsxfoOxKwNS6WCPksn3j7J35BUZO9kvx4d5wLXVt0983LqMU8ajQyNcmn4546XrJIAJ9unmQkd1xwqGCATXTkdvNvs+RG5ydriK0OxyGZKTyrr+eDML6aPg==</SignatureValue>
+          <SignatureValue>KCxrZ59qrtPYGHZWNCcENJM2gO2fNYMh3csf9MXuck6v3p0PU5k8oDHn1LHCZh/RdX/MaZu6bR/yk5h2Wy+11ZEa/U5ELm34iCNVvHVxeq3baBqdLGEjnWdApD00Lb1jr5sMeEtJGvbC+JUVyc57CEgHYCRAFGIV/kK654YqkIa6z/8NAQDEWDSDq9HPYHqu+RRxeAbDSbWpndzDvI91AfUc5fMwWaq7tTvh9sIJS6aCXmS0BlU/uDb6NkWHF46DFR9Pu2Q0qhNnmU1REATQLv5cDiSNesbtUCaHmCyLBsFGnb46Jc8YzrxHXIzRc4uVYdemG2XI5LqTwB0Qwp01zA==</SignatureValue>
           <KeyInfo>
             <X509Data>
               <X509IssuerSerial>

--- a/tests/_files/query/request-received.xml
+++ b/tests/_files/query/request-received.xml
@@ -4,7 +4,7 @@
   <s:Body>
     <des:SolicitaDescarga>
       <des:solicitud FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcSolicitante="EKU9003173C9" TipoSolicitud="CFDI">
-        <des:RfcRecibidos><des:RfcRecibido>EKU9003173C9</des:RfcRecibido></des:RfcRecibidos>
+        <des:RfcReceptores><des:RfcReceptor>EKU9003173C9</des:RfcReceptor></des:RfcReceptores>
         <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
           <SignedInfo>
             <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -14,10 +14,10 @@
                 <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
               </Transforms>
               <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-              <DigestValue>UCLUy9DlqZ3gGXY76XEJHa/tnLE=</DigestValue>
+              <DigestValue>Xni0ddqcMpbkuC4CgKua4IWtQ3U=</DigestValue>
             </Reference>
           </SignedInfo>
-          <SignatureValue>HkYlLZekMoaUBzUvzPB4zxr78DQeC0jcnfMmmALPgNhomVvhf/vhBg67bXBtYGsaFAgyo4Q/J0Fs2kc+BAmYOFmdahCTV0TKVvqYi1MgsRpiMYGrU0MTF35B2ndYS7AK+IfmeRHe6iEoOHKJoP0Xy4ikcSxdpwAl+Myo+WbAZCzFsBjFqGsvknGDAWMixSE0RIwKtpnG8TOS3njvyHm/qwxot3bnKSTj3tHpGbj/2s2yEw8tozLcvL1/DxbSmNmWxWKh6FblYWRt2LI7GMqOH+gzJtxz5XbbDxkzh529qXmon3Zn5i0ZoGkxS3eutsWWbI0kf00sHLY7qh8ydLjtPA==</SignatureValue>
+          <SignatureValue>WTeQ/u5Od4saZHZEdRjf8LdabLtSl0M+a2rBatHIlgsJzeL2FrrWVdvlU7s8aWpWN31Jfm6U48OaOtr/rVhDV+b7ZbDOZ0xnWiWE0FqedTm63siuhAJx+zDPM1PaREfA1zlKbxdGdOdjN4NmGDvEuh4XCJzBr15ekjA5irTkE8hUyAyvaXzjzy6G/OPzkbBC7LEXE0IvdxzNsdxnNOWZmY16oh2bImrrRE5aeMzYyMPkepDLFkQ7N+8ssNO5pT3iFCCELa6TiHWPQLlK8vnXPHRS8SWAIkMe13tG2lUt/3Hyz3zJbyifL6TQQTiefJ+DauvwqXludmmxj1i2URSmEQ==</SignatureValue>
           <KeyInfo>
             <X509Data>
               <X509IssuerSerial>


### PR DESCRIPTION
Se actualizó el servicio de solicitud de descargas masivas (consulta) a la versión 1.2 del SAT.
Esta actualización por el momento solo está sobre CFDI regulares, no sobre Retenciones e información de pagos.
En este último el servicio se encuentra caído.

Al parecer la actualización no se ha completado en el SAT, y ha estado inestable desde 2022-03-14.
Sin embargo, con esta actualización se compatibliza el servicio con el funcionamiento esperado.

### Cambios en la solicitud

Se elimina el atributo `RfcReceptor` y se agrega el elemento `RfcReceptores/RfcReceptor` para especificar
el RFC del receptor en la consulta.

### CodEstatus 5006

Se agrega a la documentación de `CodEstatus` (clase `StatusCode`) el código `5006 - Error interno en el proceso`
que se supone sustituye al código `404 - Error no Controlado` para el servicio de consulta.

### Correcciones

Se agrega el método mágico `MetadataItem::__isset(string $name): bool` que no estaba contemplado.

### Entorno de desarrollo

- En las pruebas de integración, se hacen dos pruebas de solicitud consulta, una para emitidos y otra para recibidos.
- Se actualizan los archivos de muestra en las comprobaciones unitarias.
- Se agrega como dependencia la extensión de PHP `mbstring`.
- Se refactoriza la clase interna `Helpers::nospaces()` para insertar un *Line feed (LF)*.
  después de la especificación de XML.
- En las pruebas de integración, se agrega el método `ConsumeServiceTestCase::createWebClient()`
  que devuelve un objeto `GuzzleHttp\Client` configurado correctamente con *timeouts*.
- Se actualizan las herramientas del entorno de desarrollo.
- CI: Se usan las rutas establecidas en el archivo de configuración de `phpcs`.

Ver https://github.com/phpcfdi/sat-ws-descarga-masiva/issues/47