### PR TITLE
Propuesta de compatibilidad versión 0.4.5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,15 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Versión 0.4.5 2022-03-22
+
+Se compatibilizó la colocación de una consulta con el servicio de solicitud de descargas masivas
+*para CFDI de Retenciones e Información de Pagos*, anteriormente, al solicitar XML el valor del
+atributo `TipoSolicitud` debía ser `CFDI` y ahora debe ser `Retencion`.
+
+Este cambio altera la API pública, pero no se considera un cambio que rompa la compatibilidad
+porque el cambio ocurrió sobre la clase `QueryTranslator` marcada como `@internal`.
+
 ## Versión 0.4.4 2022-03-12
 
 Se actualizó el servicio de solicitud de descargas masivas (consulta) a la versión 1.2 del SAT.

--- a/src/RequestBuilder/Exceptions/RequestTypeInvalidException.php
+++ b/src/RequestBuilder/Exceptions/RequestTypeInvalidException.php
@@ -14,7 +14,7 @@ final class RequestTypeInvalidException extends LogicException implements Reques
 
     public function __construct(string $requestType)
     {
-        parent::__construct(sprintf('The request type "%s" is not CFDI or Metadata', $requestType));
+        parent::__construct(sprintf('The request type "%s" is not CFDI, Retencion or Metadata', $requestType));
         $this->requestType = $requestType;
     }
 

--- a/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
+++ b/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
@@ -97,7 +97,7 @@ final class FielRequestBuilder implements RequestBuilderInterface
         if (! in_array($rfcSigner, [$rfcReceiver, $rfcIssuer], true)) {
             throw new RfcIsNotIssuerOrReceiverException($rfcSigner, $rfcIssuer, $rfcReceiver);
         }
-        if (! in_array($requestType, ['CFDI', 'Metadata'], true)) {
+        if (! in_array($requestType, ['CFDI', 'Retencion', 'Metadata'], true)) {
             throw new RequestTypeInvalidException($requestType);
         }
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -95,7 +95,8 @@ class Service
     public function query(QueryParameters $parameters): QueryResult
     {
         $queryTranslator = new QueryTranslator();
-        $soapBody = $queryTranslator->createSoapRequest($this->requestBuilder, $parameters);
+        $isRetenciones = $this->endpoints->getQuery() === ServiceEndpoints::retenciones()->getQuery();
+        $soapBody = $queryTranslator->createSoapRequest($this->requestBuilder, $parameters, $isRetenciones);
         $responseBody = $this->consume(
             'http://DescargaMasivaTerceros.sat.gob.mx/ISolicitaDescargaService/SolicitaDescarga',
             $this->endpoints->getQuery(),

--- a/src/Services/Query/QueryTranslator.php
+++ b/src/Services/Query/QueryTranslator.php
@@ -23,13 +23,19 @@ class QueryTranslator
         return new QueryResult($status, $requestId);
     }
 
-    public function createSoapRequest(RequestBuilderInterface $requestBuilder, QueryParameters $parameters): string
-    {
+    public function createSoapRequest(
+        RequestBuilderInterface $requestBuilder,
+        QueryParameters $parameters,
+        bool $isRetenciones
+    ): string {
         $start = $parameters->getPeriod()->getStart()->format('Y-m-d\TH:i:s');
         $end = $parameters->getPeriod()->getEnd()->format('Y-m-d\TH:i:s');
         $rfcIssuer = $parameters->getDownloadType()->isIssued() ? RequestBuilderInterface::USE_SIGNER : $parameters->getRfcMatch();
         $rfcReceiver = $parameters->getDownloadType()->isReceived() ? RequestBuilderInterface::USE_SIGNER : $parameters->getRfcMatch();
         $requestType = $parameters->getRequestType()->value();
+        if ($parameters->getRequestType()->isCfdi() && $isRetenciones) {
+            $requestType = 'Retencion';
+        }
 
         /** @noinspection PhpUnhandledExceptionInspection */
         return $requestBuilder->query($start, $end, $rfcIssuer, $rfcReceiver, $requestType);

--- a/tests/Unit/RequestBuilder/Exceptions/RequestTypeInvalidExceptionTest.php
+++ b/tests/Unit/RequestBuilder/Exceptions/RequestTypeInvalidExceptionTest.php
@@ -20,7 +20,7 @@ final class RequestTypeInvalidExceptionTest extends TestCase
     {
         $requestType = 'foo';
         $exception = new RequestTypeInvalidException($requestType);
-        $this->assertSame('The request type "foo" is not CFDI or Metadata', $exception->getMessage());
+        $this->assertSame('The request type "foo" is not CFDI, Retencion or Metadata', $exception->getMessage());
         $this->assertSame($requestType, $exception->getRequestType());
     }
 }

--- a/tests/Unit/Services/Query/QueryTranslatorTest.php
+++ b/tests/Unit/Services/Query/QueryTranslatorTest.php
@@ -42,7 +42,7 @@ class QueryTranslatorTest extends TestCase
             RequestType::cfdi()
         );
 
-        $requestBody = $translator->createSoapRequest($requestBuilder, $query);
+        $requestBody = $translator->createSoapRequest($requestBuilder, $query, false);
         $this->assertSame(
             $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-received.xml'))),
             $this->xmlFormat($requestBody)


### PR DESCRIPTION
Se compatibilizó la colocación de una consulta con el servicio de solicitud de descargas masivas
*para CFDI de Retenciones e Información de Pagos*, anteriormente, al solicitar XML el valor del
atributo `TipoSolicitud` debía ser `CFDI` y ahora debe ser `Retencion`.

Este cambio altera la API pública, pero no se considera un cambio que rompa la compatibilidad
porque el cambio ocurrió sobre la clase `QueryTranslator` marcada como `@internal`.