### PR TITLE
Corrección de codificación de `RfcReceptor` (v0.4.7)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,12 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
-## Unreleased 2022-07-25
+## Versión 0.4.7 2022-08-10
+
+No se estaba haciendo la codificación correcta de `RfcReceptor`, que provocaba un fallo cuando se solicitaba
+una consulta donde el RFC recibido tuviera un ampersand `&`.
+
+### Cambios previos 2022-07-25
 
 La clase `MicroCatalog` requiere la definición de datos extendidos, no estaban definidos y entonces
 el proceso de integración continua falló. Se agregaron para hacer esta corrección.

--- a/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
+++ b/src/RequestBuilder/FielRequestBuilder/FielRequestBuilder.php
@@ -119,7 +119,10 @@ final class FielRequestBuilder implements RequestBuilderInterface
         ));
         $xmlRfcReceived = '';
         if ('' !== $rfcReceiver) {
-            $xmlRfcReceived = "<des:RfcReceptores><des:RfcReceptor>${rfcReceiver}</des:RfcReceptor></des:RfcReceptores>";
+            $xmlRfcReceived = sprintf(
+                '<des:RfcReceptores><des:RfcReceptor>%s</des:RfcReceptor></des:RfcReceptores>',
+                htmlspecialchars($rfcReceiver, ENT_XML1)
+            );
         }
 
         $toDigestXml = <<<EOT


### PR DESCRIPTION
No se estaba haciendo la codificación correcta de `RfcReceptor`, que provocaba un fallo cuando se solicitaba una consulta donde el RFC recibido tuviera un ampersand `&`.
