### PR TITLE
Filter by UUID (version 0.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Puede que los cambios del ejemplo no sean lógicos, es solo para ilustrar cómo 
 - Filtrando por únicamente documentos vigentes (excluye cancelados).
 - Filtrando por el RFC a cuenta de terceros `XXX01010199A`.
 - Filtrando por el RFC contraparte `MAG041126GT8`. Como se solicitan recibidos, entonces son los emidos por ese RFC.
-- Filtrando por el UUID `96623061-61fe-49de-b298-c7156476aa8b`
+- Filtrando por el UUID `96623061-61fe-49de-b298-c7156476aa8b`.
 
 ```php
 <?php
@@ -297,6 +297,23 @@ $query = QueryParameters::create()
     ->withDocumentStatus(DocumentStatus::active())
     ->withRfcOnBehalf(RfcOnBehalf::create('XXX01010199A'))
     ->withRfcMatch(RfcMatch::create('MAG041126GT8'))
+    ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
+;
+```
+
+#### Ejemplo de consulta por UUID
+
+En este caso se especifica solamente el UUID a consultar, en el ejemplo es `96623061-61fe-49de-b298-c7156476aa8b`.
+
+Nota: **Todos los demás argumentos de la consulta son ignorados**.
+
+```php
+<?php
+
+use PhpCfdi\SatWsDescargaMasiva\Services\Query\QueryParameters;
+use PhpCfdi\SatWsDescargaMasiva\Shared\Uuid;
+
+$query = QueryParameters::create()
     ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
 ;
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,20 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Versión 0.5.2 2022-09-30
+
+#### Consulta por UUID
+
+Gracias a la solicitud de cambios en [`luisiturrios1/python-cfdiclient#42`](https://github.com/luisiturrios1/python-cfdiclient/pull/42)
+por `@alan196`, hemos podido verificar que la documentación del servicio con respecto a la consulta por UUID está incorrecta.
+
+- El campo no se llama `UUID`, se llama `Folio`.
+- El campo `RfcSolicitante` no se debe omitir.
+- El campo `TipoSolicitud` no se debe omitir.
+- Los demás campos no deben existir.
+
+Por lo tanto, se han hecho las correcciones necesarias para hacer la consulta por `UUID`.
+
 ## Versión 0.5.1 2022-09-28
 
 ### Se corrigen XML mal formados

--- a/docs/problema-filtros-no-aplicados.md
+++ b/docs/problema-filtros-no-aplicados.md
@@ -19,16 +19,23 @@ En esta versión se agregan nuevos filtros, permitiendo hacer solicitudes más e
 
 Los siguientes filtros no están funcionando en la consulta de CFDI Regulares:
 
-- Filtro por UUID.
 - Filtro de documentos cancelados cuando se solicita un paquete de documentos XML. 
   El filtro funciona correctamente para paquetes de Metadata.
 
 Los siguientes filtros no están funcionando en la consulta de CFDI de retenciones e información de pagos:
 
 - Filtro por complemento.
-- Filtro por UUID.
 
 ## Actualizaciones
+
+### 2022-09-30
+
+Hemos notado que la documentación del SAT en relación con la consulta por UUID está incorrecta:
+
+- El campo no se llama `UUID`, se llama `Folio`.
+- El campo `RfcSolicitante` se debe especificar.
+- El campo `TipoSolicitud` se debe especificar.
+- Los demás campos no deben existir.
 
 ### 2022-03-04
 

--- a/src/PackageReader/Internal/FilteredPackageReader.php
+++ b/src/PackageReader/Internal/FilteredPackageReader.php
@@ -57,18 +57,19 @@ final class FilteredPackageReader implements PackageReaderInterface
         return new self($filename, $archive);
     }
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc
+     * @codeCoverageIgnore Unable to produce code coverage for error handling
+     */
     public static function createFromContents(string $content): self
     {
         // create temp file
         try {
             $tmpfile = tempnam(sys_get_temp_dir(), '');
         } catch (Throwable $exception) {
-            /** @codeCoverageIgnore */
             throw CreateTemporaryZipFileException::create('Cannot create a temporary file', $exception);
         }
         if (false === $tmpfile) {
-            /** @codeCoverageIgnore */
             throw CreateTemporaryZipFileException::create('Cannot not create a temporary file');
         }
 
@@ -76,11 +77,9 @@ final class FilteredPackageReader implements PackageReaderInterface
         try {
             $write = file_put_contents($tmpfile, $content);
         } catch (Throwable $exception) {
-            /** @codeCoverageIgnore */
             throw CreateTemporaryZipFileException::create('Cannot store contents on temporary file', $exception);
         }
         if (false === $write) {
-            /** @codeCoverageIgnore */
             throw CreateTemporaryZipFileException::create('Cannot store contents on temporary file');
         }
 

--- a/src/Shared/RfcMatches.php
+++ b/src/Shared/RfcMatches.php
@@ -30,7 +30,7 @@ final class RfcMatches implements Countable, IteratorAggregate, JsonSerializable
         $map = [];
         foreach ($items as $item) {
             $key = $item->getValue();
-            if (! $item->isEmpty() and ! isset($map[$key])) {
+            if (! $item->isEmpty() && ! isset($map[$key])) {
                 $map[$item->getValue()] = $item;
             }
         }

--- a/tests/Integration/ConsumeCfdiServicesUsingFakeFielTest.php
+++ b/tests/Integration/ConsumeCfdiServicesUsingFakeFielTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatWsDescargaMasiva\Tests\Integration;
 
+use LogicException;
 use PhpCfdi\SatWsDescargaMasiva\Services\Query\QueryParameters;
 use PhpCfdi\SatWsDescargaMasiva\Shared\ComplementoCfdi;
 use PhpCfdi\SatWsDescargaMasiva\Shared\DateTimePeriod;
@@ -14,6 +15,7 @@ use PhpCfdi\SatWsDescargaMasiva\Shared\RequestType;
 use PhpCfdi\SatWsDescargaMasiva\Shared\RfcMatch;
 use PhpCfdi\SatWsDescargaMasiva\Shared\RfcOnBehalf;
 use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceEndpoints;
+use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceType;
 use PhpCfdi\SatWsDescargaMasiva\Shared\Uuid;
 
 final class ConsumeCfdiServicesUsingFakeFielTest extends ConsumeServiceTestCase
@@ -45,5 +47,16 @@ final class ConsumeCfdiServicesUsingFakeFielTest extends ConsumeServiceTestCase
             $result->getStatus()->getCode(),
             'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
         );
+    }
+
+    public function testServiceEndpointsDifferentThanQueryEndpointsThrowsError(): void
+    {
+        $service = $this->createService();
+
+        $otherServiceType = ServiceType::retenciones();
+        $parameters = QueryParameters::create()->withServiceType($otherServiceType);
+
+        $this->expectException(LogicException::class);
+        $service->query($parameters);
     }
 }

--- a/tests/Integration/ConsumeCfdiServicesUsingFakeFielTest.php
+++ b/tests/Integration/ConsumeCfdiServicesUsingFakeFielTest.php
@@ -36,9 +36,24 @@ final class ConsumeCfdiServicesUsingFakeFielTest extends ConsumeServiceTestCase
             ->withDocumentType(DocumentType::nomina())
             ->withComplement(ComplementoCfdi::nomina12())
             ->withDocumentStatus(DocumentStatus::active())
-            ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
             ->withRfcOnBehalf(RfcOnBehalf::create('XXX01010199A'))
             ->withRfcMatch(RfcMatch::create('AAA010101AAA'))
+        ;
+
+        $result = $service->query($parameters);
+        $this->assertSame(
+            305,
+            $result->getStatus()->getCode(),
+            'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
+        );
+    }
+
+    public function testQueryUuid(): void
+    {
+        $service = $this->createService();
+
+        $parameters = QueryParameters::create()
+            ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
         ;
 
         $result = $service->query($parameters);

--- a/tests/Integration/ConsumeRetencionesServicesUsingFakeFielTest.php
+++ b/tests/Integration/ConsumeRetencionesServicesUsingFakeFielTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatWsDescargaMasiva\Tests\Integration;
 
+use LogicException;
 use PhpCfdi\SatWsDescargaMasiva\Services\Query\QueryParameters;
 use PhpCfdi\SatWsDescargaMasiva\Shared\ComplementoRetenciones;
 use PhpCfdi\SatWsDescargaMasiva\Shared\DateTimePeriod;
@@ -13,6 +14,7 @@ use PhpCfdi\SatWsDescargaMasiva\Shared\RequestType;
 use PhpCfdi\SatWsDescargaMasiva\Shared\RfcMatch;
 use PhpCfdi\SatWsDescargaMasiva\Shared\RfcOnBehalf;
 use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceEndpoints;
+use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceType;
 use PhpCfdi\SatWsDescargaMasiva\Shared\Uuid;
 
 /**
@@ -46,5 +48,16 @@ final class ConsumeRetencionesServicesUsingFakeFielTest extends ConsumeServiceTe
             $result->getStatus()->getCode(),
             'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
         );
+    }
+
+    public function testServiceEndpointsDifferentThanQueryEndpointsThrowsError(): void
+    {
+        $service = $this->createService();
+
+        $otherServiceType = ServiceType::cfdi();
+        $parameters = QueryParameters::create()->withServiceType($otherServiceType);
+
+        $this->expectException(LogicException::class);
+        $service->query($parameters);
     }
 }

--- a/tests/Integration/ConsumeRetencionesServicesUsingFakeFielTest.php
+++ b/tests/Integration/ConsumeRetencionesServicesUsingFakeFielTest.php
@@ -27,7 +27,7 @@ final class ConsumeRetencionesServicesUsingFakeFielTest extends ConsumeServiceTe
         return ServiceEndpoints::retenciones();
     }
 
-    public function testQueryChangeAllParameters(): void
+    public function testQueryChangeFilters(): void
     {
         $service = $this->createService();
 
@@ -37,9 +37,24 @@ final class ConsumeRetencionesServicesUsingFakeFielTest extends ConsumeServiceTe
             ->withRequestType(RequestType::xml())
             ->withComplement(ComplementoRetenciones::undefined())
             ->withDocumentStatus(DocumentStatus::active())
-            ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
             ->withRfcOnBehalf(RfcOnBehalf::create('XXX01010199A'))
             ->withRfcMatch(RfcMatch::create('AAA010101AAA'))
+        ;
+
+        $result = $service->query($parameters);
+        $this->assertSame(
+            305,
+            $result->getStatus()->getCode(),
+            'Expected to receive a 305 - Certificado Inválido from SAT since FIEL is for testing'
+        );
+    }
+
+    public function testQueryByUuid(): void
+    {
+        $service = $this->createService();
+
+        $parameters = QueryParameters::create()
+            ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
         ;
 
         $result = $service->query($parameters);

--- a/tests/Unit/PackageReader/Internal/ThirdPartiesExtractorTest.php
+++ b/tests/Unit/PackageReader/Internal/ThirdPartiesExtractorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\PackageReader\Internal;
+
+use ArrayIterator;
+use LogicException;
+use PhpCfdi\SatWsDescargaMasiva\PackageReader\Internal\CsvReader;
+use PhpCfdi\SatWsDescargaMasiva\PackageReader\Internal\FileFilters\NullFileFilter;
+use PhpCfdi\SatWsDescargaMasiva\PackageReader\Internal\FilteredPackageReader;
+use PhpCfdi\SatWsDescargaMasiva\PackageReader\Internal\ThirdPartiesExtractor;
+use PhpCfdi\SatWsDescargaMasiva\PackageReader\PackageReaderInterface;
+use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+
+final class ThirdPartiesExtractorTest extends TestCase
+{
+    public function testExtractor(): void
+    {
+        $source = [
+            ['Uuid', 'RfcACuentaTerceros', 'NombreACuentaTerceros'],
+            ['00000000-aaaa-bbbb-1111-000000000001', 'AAAA010101AAA', 'Registro de ejemplo 1'],
+            ['00000000-aaaa-bbbb-1111-000000000002', 'AAAA010102AAA', 'Registro de ejemplo 2'],
+            ['00000000-aaaa-bbbb-1111-000000000003', 'AAAA010103AAA', 'Registro de ejemplo 3'],
+        ];
+        $expected = [
+            '00000000-AAAA-BBBB-1111-000000000001' => [
+                'RfcACuentaTerceros' => 'AAAA010101AAA',
+                'NombreACuentaTerceros' => 'Registro de ejemplo 1',
+            ],
+            '00000000-AAAA-BBBB-1111-000000000002' => [
+                'RfcACuentaTerceros' => 'AAAA010102AAA',
+                'NombreACuentaTerceros' => 'Registro de ejemplo 2',
+            ],
+            '00000000-AAAA-BBBB-1111-000000000003' => [
+                'RfcACuentaTerceros' => 'AAAA010103AAA',
+                'NombreACuentaTerceros' => 'Registro de ejemplo 3',
+            ],
+        ];
+        $extractor = new ThirdPartiesExtractor(new CsvReader(new ArrayIterator($source)));
+        $this->assertSame($expected, iterator_to_array($extractor->eachRecord()));
+    }
+
+    public function testEmptyUuidIsIgnored(): void
+    {
+        $source = [
+            ['Uuid', 'RfcACuentaTerceros', 'NombreACuentaTerceros'],
+            ['', 'AAAA010101AAA', 'Registro de ejemplo 1'],
+        ];
+        $expected = [];
+        $extractor = new ThirdPartiesExtractor(new CsvReader(new ArrayIterator($source)));
+        $this->assertSame($expected, iterator_to_array($extractor->eachRecord()));
+    }
+
+    public function testCreateFromPackageReaderNotFilteredPackageReader(): void
+    {
+        $packageReader = $this->createMock(PackageReaderInterface::class);
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('PackageReader parameter must be a FilteredPackageReader');
+        ThirdPartiesExtractor::createFromPackageReader($packageReader);
+    }
+
+    public function testCreateFromPackageReaderRestoreFilter(): void
+    {
+        $packageReader = FilteredPackageReader::createFromFile($this->filePath('zip/metadata.zip'));
+        $filter = new NullFileFilter();
+        $packageReader->setFilter($filter);
+
+        ThirdPartiesExtractor::createFromPackageReader($packageReader);
+
+        $this->assertSame(
+            $filter,
+            $packageReader->getFilter(),
+            'FilteredPackageReader filter must not change after call createFromPackageReader'
+        );
+    }
+}

--- a/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
+++ b/tests/Unit/RequestBuilder/FielRequestBuilder/FielRequestBuilderTest.php
@@ -91,7 +91,7 @@ class FielRequestBuilderTest extends TestCase
         return $matches['id'] ?? '';
     }
 
-    public function testQueryReceived(): void
+    public function testQueryReceivedByFilters(): void
     {
         $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
         $parameters = QueryParameters::create()
@@ -102,14 +102,32 @@ class FielRequestBuilderTest extends TestCase
             ->withDocumentType(DocumentType::nomina())
             ->withComplement(ComplementoCfdi::nomina12())
             ->withDocumentStatus(DocumentStatus::active())
-            ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
             ->withRfcOnBehalf(RfcOnBehalf::create('XXX01010199A'))
             ->withRfcMatch(RfcMatch::create('AAA010101AAA'))
         ;
         $requestBody = $requestBuilder->query($parameters);
 
         $this->assertSame(
-            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-received.xml'))),
+            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-received-by-filters.xml'))),
+            $this->xmlFormat($requestBody)
+        );
+
+        $xmlSecVerification = (new EnvelopSignatureVerifier())
+            ->verify($requestBody, 'http://DescargaMasivaTerceros.sat.gob.mx', 'SolicitaDescarga');
+        $this->assertTrue($xmlSecVerification, 'The signature cannot be verified using XMLSecLibs');
+    }
+
+    public function testQueryReceivedByUuid(): void
+    {
+        $requestBuilder = $this->createFielRequestBuilderUsingTestingFiles();
+        $parameters = QueryParameters::create()
+            ->withServiceType(ServiceType::cfdi())
+            ->withUuid(Uuid::create('96623061-61fe-49de-b298-c7156476aa8b'))
+        ;
+        $requestBody = $requestBuilder->query($parameters);
+
+        $this->assertSame(
+            $this->xmlFormat(Helpers::nospaces($this->fileContents('query/request-received-by-uuid.xml'))),
             $this->xmlFormat($requestBody)
         );
 

--- a/tests/Unit/RequestBuilder/FielRequestBuilder/FielTest.php
+++ b/tests/Unit/RequestBuilder/FielRequestBuilder/FielTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\RequestBuilder\FielRequestBuilder;
 
 use Exception;
+use PhpCfdi\Credentials\Certificate;
+use PhpCfdi\Credentials\Credential;
+use PhpCfdi\Credentials\Internal\SatTypeEnum;
+use PhpCfdi\Credentials\PrivateKey;
 use PhpCfdi\SatWsDescargaMasiva\RequestBuilder\FielRequestBuilder\Fiel;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
 
@@ -49,6 +53,18 @@ class FielTest extends TestCase
             $this->fileContents('fake-csd/EKU9003173C9.key'),
             trim($this->fileContents('fake-csd/EKU9003173C9-password.txt'))
         );
+        $this->assertFalse($fiel->isValid());
+    }
+
+    public function testIsNotValidExpiredCertificate(): void
+    {
+        $certificate = $this->createMock(Certificate::class);
+        $certificate->method('satType')->willReturn(SatTypeEnum::fiel());
+        $certificate->method('validOn')->willReturn(false);
+        $privateKey = $this->createMock(PrivateKey::class);
+        $privateKey->method('belongsTo')->willReturn(true);
+        $credential = new Credential($certificate, $privateKey);
+        $fiel = new Fiel($credential);
         $this->assertFalse($fiel->isValid());
     }
 }

--- a/tests/Unit/Shared/ServiceTypeTest.php
+++ b/tests/Unit/Shared/ServiceTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Shared;
+
+use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceType;
+use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+
+final class ServiceTypeTest extends TestCase
+{
+    public function testEqualTo(): void
+    {
+        $firstCfdi = ServiceType::cfdi();
+
+        $this->assertTrue($firstCfdi->equalTo($firstCfdi));
+        $this->assertTrue($firstCfdi->equalTo(ServiceType::cfdi()));
+        $this->assertFalse($firstCfdi->equalTo(ServiceType::retenciones()));
+    }
+
+    /** @return array<string, array{ServiceType}> */
+    public function providerServiceTypes(): array
+    {
+        return [
+            'cfdi' => [ServiceType::cfdi()],
+            'retenciones' => [ServiceType::retenciones()],
+        ];
+    }
+
+    /** @dataProvider providerServiceTypes */
+    public function testJsonEncode(ServiceType $serviceType): void
+    {
+        $json = json_encode($serviceType);
+        $expected = json_encode($serviceType->value());
+        $this->assertSame($expected, $json);
+    }
+}

--- a/tests/_files/query/request-received-by-filters.xml
+++ b/tests/_files/query/request-received-by-filters.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:des="http://DescargaMasivaTerceros.sat.gob.mx" xmlns:xd="http://www.w3.org/2000/09/xmldsig#">
+  <s:Header/>
+  <s:Body>
+    <des:SolicitaDescarga>
+      <des:solicitud Complemento="nomina12" EstadoComprobante="1" FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcACuentaTerceros="XXX01010199A" RfcEmisor="AAA010101AAA" RfcSolicitante="EKU9003173C9" TipoComprobante="N" TipoSolicitud="CFDI">
+        <des:RfcReceptores>
+          <des:RfcReceptor>EKU9003173C9</des:RfcReceptor>
+        </des:RfcReceptores>
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <SignedInfo>
+            <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+            <Reference URI="">
+              <Transforms>
+                <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+              </Transforms>
+              <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+              <DigestValue>urJ4pg32vV2oozJcBBKRcxoAydo=</DigestValue>
+            </Reference>
+          </SignedInfo>
+          <SignatureValue>U0+zQI1YH5DGtlULhm01lGwoBd1vdbIv/myz/gPshujerNvRzzw9mhGCCq8E7BMsLKefbl4TTOOkL5wvFqczzcKrHS8lFTkw7073CIPVrUyhbajCaqDGRtTvHx84xpi83vknZJhuOu+Pl6gyNIu/g4/MSFtSZ9CKqIu62VBAuepGggY2jsceyMIqNhtLOuR9yGSPR2kTABypkIjvyK9NqM/JivCmHV3FXv6280eHcf40gAtHpTw++ERSRuhW/rkimyJrHLIeMvZpfT9JpORsUCbUHmdEOQae0zXHp0mcGV0woWiRKSBcA2yogl+rrqLc1cbsX5I6jfYTdaegcoe0eQ==</SignatureValue>
+          <KeyInfo>
+            <X509Data>
+              <X509IssuerSerial>
+                <X509IssuerName>CN=AC UAT,O=SERVICIO DE ADMINISTRACION TRIBUTARIA,OU=SAT-IES Authority,emailAddress=oscar.martinez@sat.gob.mx,street=3ra cerrada de cadiz,postalCode=06370,C=MX,ST=CIUDAD DE MEXICO,L=COYOACAN,x500UniqueIdentifier=2.5.4.45,unstructuredName=responsable: ACDMA-SAT</X509IssuerName>
+                <X509SerialNumber>292233162870206001759766198444326234574038511927</X509SerialNumber>
+              </X509IssuerSerial>
+              <X509Certificate>MIIGBDCCA+ygAwIBAgIUMzAwMDEwMDAwMDA0MDAwMDI0MTcwDQYJKoZIhvcNAQELBQAwggErMQ8wDQYDVQQDDAZBQyBVQVQxLjAsBgNVBAoMJVNFUlZJQ0lPIERFIEFETUlOSVNUUkFDSU9OIFRSSUJVVEFSSUExGjAYBgNVBAsMEVNBVC1JRVMgQXV0aG9yaXR5MSgwJgYJKoZIhvcNAQkBFhlvc2Nhci5tYXJ0aW5lekBzYXQuZ29iLm14MR0wGwYDVQQJDBQzcmEgY2VycmFkYSBkZSBjYWRpejEOMAwGA1UEEQwFMDYzNzAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBDSVVEQUQgREUgTUVYSUNPMREwDwYDVQQHDAhDT1lPQUNBTjERMA8GA1UELRMIMi41LjQuNDUxJTAjBgkqhkiG9w0BCQITFnJlc3BvbnNhYmxlOiBBQ0RNQS1TQVQwHhcNMTkwNjE0MjEwNTE1WhcNMjMwNjEzMjEwNTE1WjCB+TEnMCUGA1UEAxMeRVNDVUVMQSBLRU1QRVIgVVJHQVRFIFNBIERFIENWMScwJQYDVQQpEx5FU0NVRUxBIEtFTVBFUiBVUkdBVEUgU0EgREUgQ1YxJzAlBgNVBAoTHkVTQ1VFTEEgS0VNUEVSIFVSR0FURSBTQSBERSBDVjELMAkGA1UEBhMCTVgxKDAmBgkqhkiG9w0BCQEWGVNBVHBydWViYXNAcHJ1ZWJhcy5nb2IubXgxJTAjBgNVBC0THEVLVTkwMDMxNzNDOSAvIFhJUUI4OTExMTZRRTQxHjAcBgNVBAUTFSAvIFhJUUI4OTExMTZNR1JNWlIwNTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIOGnb6RqDyBhK3RDspzJCf5m4gx+lkCzQTvNEphr2GfZ3XyFHDnMeP4+IPz8XdZzQ8WSjd7JeOr5ef/9omLp4Xd6PCh83WmiTZniNPluctYs6WGDGcm/GCAlp4iIyunXX5TJvMAje8Qv8LIm+EmitE/5+OcfPLhDQA/9D34L3D8adoIuUg8UyjK3M8dj62hAkBRDUF/0Z4zPhAPX/BER7lEdZRcDrTo1M0eq8SM09+Q7ItXkMYIBf9Q3JDHfpOnD4JbAJ4dK60ZkUQI0xo+G6is4EAXv02liSRCIfEvlJrZHwGZOUaRccfj2fhRLob90Jbml4NKCURGboijoIuhTiMCAwEAAaNPME0wDAYDVR0TAQH/BAIwADALBgNVHQ8EBAMCA9gwEQYJYIZIAYb4QgEBBAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMEBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAgEAr9uInaTMf6UqST5xpEonsbOeqdnyQsG1ZiYLKw7lnjMjkYkrenManFXkpxHUeWw8Y/4y48iNcmrs1AH+Gd7ZdOJ3XIqIEy0C/SM4GemRx+YMjfsif24dxTN1fD8cU86W1Y56e3rDfgsR9yT/sGmxqvkUN3sQElyD2+qhUZUydK7i03bWIG5fyzGIi15YBhzE6ALuX8po2coUlwQV830zRBPGDkcomejsfKPjYKQ+yzUtwO+8Klr1PUHmdlaG7Gv4llWLNvKm21qAgxjMkiKHLp1Cr66W1ahks8I8VqsLarSKDzGf42VstQpO0hLV1cWXk920nl+n4htYgE7KDQwpioZXFeXCd9KiZcEREn/gvHi6nq6awPJS7k6hBPFEAtbmzwykQ30MNdtHwUXRKAf1yru9VYGIs38ElZyU8C6JJ0MPx/f/N56yHYOYKtYD++STWgXjHD0c/RPV5j1nhjPFhRMHZAuxOwQxky28MQak+pd7OF5cDJiGYfDQZ7G+riGkhodIGS+jmexWQn0tpoZt8U+Ay7L8P7fdqcV9P58AMz4Eie3VrPs2LfpbhNpD/26AvgbkE4Iz4HAOdW9AH1im3Ae8+nWuICnbWcmExqcRqykM1U7MXkOV23L3jtdvDKcP+uCudwL+9Iit6K5pCGvqw7e/uCK0/OyhtyxgA0LDS2A=</X509Certificate>
+            </X509Data>
+          </KeyInfo>
+        </Signature>
+      </des:solicitud>
+    </des:SolicitaDescarga>
+  </s:Body>
+</s:Envelope>

--- a/tests/_files/query/request-received-by-uuid.xml
+++ b/tests/_files/query/request-received-by-uuid.xml
@@ -3,8 +3,7 @@
   <s:Header/>
   <s:Body>
     <des:SolicitaDescarga>
-      <des:solicitud Complemento="nomina12" EstadoComprobante="1" FechaFinal="2019-01-01T00:04:00" FechaInicial="2019-01-01T00:00:00" RfcACuentaTerceros="XXX01010199A" RfcEmisor="AAA010101AAA" RfcSolicitante="EKU9003173C9" TipoComprobante="N" TipoSolicitud="CFDI" UUID="96623061-61fe-49de-b298-c7156476aa8b">
-        <des:RfcReceptores><des:RfcReceptor>EKU9003173C9</des:RfcReceptor></des:RfcReceptores>
+      <des:solicitud Folio="96623061-61fe-49de-b298-c7156476aa8b" RfcSolicitante="EKU9003173C9" TipoSolicitud="Metadata">
         <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
           <SignedInfo>
             <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -14,10 +13,10 @@
                 <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
               </Transforms>
               <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-              <DigestValue>lvCqCw1nWeW7biQuSsjD2KltrQ4=</DigestValue>
+              <DigestValue>A0teWlShxOD/65O111KTBA+TOSk=</DigestValue>
             </Reference>
           </SignedInfo>
-          <SignatureValue>KSTQj+KcLjZEw2iLt2YZn/KB7b96ciHZLci9cHAKl/uGkt7XpQnV1X18ZX9spZZZvlkQyH/gDoEgtMA0yb1oO6ACO66hnfQTaY6b3luhIKrIN9VOdBus6ymrKNhj4mI+ev+HIn1jX1vH8KuVm0lcQ87via8RoOulyvR7lmbuSGILJsshGheofV+eibBdqWe8ukGYYu/iXE9xp+NmI2ltNYizn8fM3wV7F7H51WoJL0lokapcnRk3AeQAbwWw9Yh1dCsb1CqhyRQp6D9fOHpPbQSdhdpdHn774DbH/sqG658Hvx343WrwjDzotLPLVKfGnSTcihDSka6nqXb+EGc4UQ==</SignatureValue>
+          <SignatureValue>d0KaOIjhmXRKuSmbqP/tFoyEqBiNwab5rd8L9mCnjg0TxtbRgJz9+5I7LP0JwJiVWlzcPFoOwth68vSmFqr+hEtvpYlYPmUrPMMiheIv+6D28DLErBlZSRmnXuu3EJuI7D29JAMB2MYML8N8n8Y/NOLGhO3qQIJDAa8AjQCIxgokipU9iZsHtDcHcHZOocCFMWNOBTDLdd8TOsi6HNgWEDeUL18nJ7W1QOamQAU3fmKSPF3I37pISu/MHExPayqDZEaDkbKl0u9j8GGSlFyOreLjvkyfZWj9azlu/jyMIy/DwlEeIviPrccc/nnDQ1T3wYrB2QNeSeP7Xb8QCOx+ug==</SignatureValue>
           <KeyInfo>
             <X509Data>
               <X509IssuerSerial>


### PR DESCRIPTION
Gracias a la solicitud de cambios en [`luisiturrios1/python-cfdiclient#42`](https://github.com/luisiturrios1/python-cfdiclient/pull/42) por @alan196, hemos podido verificar que la documentación del servicio con respecto a la consulta por UUID está incorrecta.

- El campo no se llama `UUID`, se llama `Folio`.
- El campo `RfcSolicitante` no se debe omitir.
- El campo `TipoSolicitud` no se debe omitir.
- Los demás campos no deben existir.

Por lo tanto, se han hecho las correcciones necesarias para hacer la consulta por `UUID`.
