### PR TITLE
docs: change array type from string[] to array<string, string>

### DIFF
--- a/src/PackageReader/Internal/MetadataContent.php
+++ b/src/PackageReader/Internal/MetadataContent.php
@@ -68,8 +68,8 @@ final class MetadataContent
     }
 
     /**
-     * @param string[] $data
-     * @return string[]
+     * @param array<string, string> $data
+     * @return array<string, string>
      */
     private function changeArrayKeysFirstLetterLowerCase(array $data): array
     {


### PR DESCRIPTION
- the array comment type  in function `changeArrayKeysFirstLetterLowerCase` for param and return was: `string[]` but the right type is: `array<string, string>`.