### PR TITLE
Mantenimiento 2023-07-10

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.18.0" installed="3.18.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.21.1" installed="3.21.1" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.19" installed="1.10.19" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.10.25" installed="1.10.25" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,14 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Mantenimiento 2023-07-10
+
+- El proceso de integración continua falló en PHP 8.1 y PHP 8.2 al momento de verificar la firma de un mensaje SOAP firmado.
+  En algunas ocasiones se consulta el espacio de nombres, pero no se encuentra el prefijo.
+  Esto se ha solucionado consultando el mensaje original `Envelope`, en lugar del mensaje sin envoltura SOAP.
+- Se actualizaron las herramientas de desarrollo.
+- En el archivo de configuración de `php-cs-fixer`, se cambió la regla obsoleta `function_typehint_space` por `type_declaration_spaces`.
+
 ## Mantenimiento 2023-06-19
 
 - Se actualiza la FIEL del RFC `EKU9003173C9` que estaba vencida.

--- a/tests/Unit/RequestBuilder/FielRequestBuilder/EnvelopSignatureVerifier.php
+++ b/tests/Unit/RequestBuilder/FielRequestBuilder/EnvelopSignatureVerifier.php
@@ -31,6 +31,15 @@ class EnvelopSignatureVerifier
     ): bool {
         $soapDocument = new DOMDocument();
         $soapDocument->loadXML($soapMessage);
+        $idNS = [];
+        $idKeys = [];
+        foreach ($includeNamespaces as $namespace) {
+            $prefix = strval($soapDocument->lookupPrefix($namespace));
+            if ('' !== $prefix) {
+                $idNS[$prefix] = $namespace;
+                $idKeys[] = "$prefix:Id";
+            }
+        }
 
         /** @var DOMElement $mainNode */
         $mainNode = $soapDocument->getElementsByTagNameNS($namespaceURI, $mainNodeName)->item(0);
@@ -49,15 +58,6 @@ class EnvelopSignatureVerifier
         );
 
         $dSig = new XMLSecurityDSig();
-        $idNS = [];
-        $idKeys = [];
-        foreach ($includeNamespaces as $namespace) {
-            $prefix = strval($document->lookupPrefix($namespace));
-            if ('' !== $prefix) {
-                $idNS[$prefix] = $namespace;
-                $idKeys[] = "$prefix:Id";
-            }
-        }
         $dSig->idNS = $idNS;
         $dSig->idKeys = $idKeys;
         $signature = $dSig->locateSignature($document);


### PR DESCRIPTION
- El proceso de integración continua falló en PHP 8.1 y PHP 8.2 al momento de verificar la firma de un mensaje SOAP firmado.
  En algunas ocasiones se consulta el espacio de nombres, pero no se encuentra el prefijo.
  Esto se ha solucionado consultando el mensaje original `Envelope`, en lugar del mensaje sin envoltura SOAP.
- Se actualizaron las herramientas de desarrollo.
- En el archivo de configuración de `php-cs-fixer`, se cambió la regla obsoleta `function_typehint_space` por `type_declaration_spaces`.
