### PR TITLE
Corrección de paquetes truncados al descargar y mantenimiento (v0.5.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -35,11 +35,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -52,11 +52,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -65,29 +65,29 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: PHPStan
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:
@@ -96,11 +96,11 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,15 +11,15 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.2 (code coverage)
+    name: Create code coverage
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -28,17 +28,17 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Create code coverage
         run: vendor/bin/phpunit --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !env.ACT }} # do not run using nektos/act
         with:
           name: code-coverage
@@ -74,28 +74,28 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
           path: build/coverage

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.37.1" installed="3.37.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.40" installed="1.10.40" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.54.0" installed="3.54.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.9.1" installed="3.9.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.9.1" installed="3.9.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.67" installed="1.10.67" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,6 +36,7 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ext-json": "*",
         "ext-zip": "*",
         "ext-mbstring": "*",
+        "ext-libxml": "*",
         "phpcfdi/credentials": "^1.1",
         "phpcfdi/rfc": "^1.1",
         "eclipxe/enum": "^0.2.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,9 @@ Al usar `LIBXML_PARSEHUGE` se está quitando una protección natural que impide 
 Sin embargo, podemos considerar segura esta acción dado que solo ocurre en el contexto de respuestas
 recibidas del servicio de descarga masiva del SAT.
 
+## Mantenimiento 2024-04-17
+
+- Se actualizaron las herramientas de desarrollo.
 
 ## Mantenimiento 2023-10-30
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ Al usar `LIBXML_PARSEHUGE` se está quitando una protección natural que impide 
 Sin embargo, podemos considerar segura esta acción dado que solo ocurre en el contexto de respuestas
 recibidas del servicio de descarga masiva del SAT.
 
+- Se actualiza el archivo de licencia a 2024.
+
 ## Mantenimiento 2024-04-17
 
 - Se actualizaron los flujos de trabajo:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ recibidas del servicio de descarga masiva del SAT.
 
 ## Mantenimiento 2024-04-17
 
+- Se mejoran las pruebas del rasgo `ComplementoTrait`.
 - Se actualizaron los flujos de trabajo:
   - Se agregó PHP 8.3 a la matriz de pruebas.
   - Los trabajos ahora corren en PHP 8.3.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,11 @@ recibidas del servicio de descarga masiva del SAT.
 
 ## Mantenimiento 2024-04-17
 
+- Se actualizaron los flujos de trabajo:
+  - Se agregó PHP 8.3 a la matriz de pruebas.
+  - Los trabajos ahora corren en PHP 8.3.
+  - Se actualizan las acciones de GitHub a la versión 4.
+  - Se cambia la variable `build/tests/matrix/php-versions` a singular.
 - Se actualizaron las herramientas de desarrollo.
 
 ## Mantenimiento 2023-10-30

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,18 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Versión 0.5.4 2024-04-17
+
+- Se corrige un bug donde en algunas ocasiones falla al procesar la respuesta de una descarga de paquetes.
+
+El método `DOMDocument::loadXML()` con `LibXML >= 1.11.0` trunca a 10,000,000 bytes el contenido de un
+nodo de tipo texto. Esto lleva a que el contenido de un paquete se trunque y el archivo ZIP descargado
+se encuentre truncado y, por lo tanto, corrupto. Se ha corregido usando la opción `LIBXML_PARSEHUGE`.
+Al usar `LIBXML_PARSEHUGE` se está quitando una protección natural que impide una denegación de servicio.
+Sin embargo, podemos considerar segura esta acción dado que solo ocurre en el contexto de respuestas
+recibidas del servicio de descarga masiva del SAT.
+
+
 ## Mantenimiento 2023-10-30
 
 - El proceso de integración continua falló al momento de verificar el estilo de código con `php-cs-fixer:3.37.1`.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>

--- a/src/Internal/InteractsXmlTrait.php
+++ b/src/Internal/InteractsXmlTrait.php
@@ -25,7 +25,8 @@ trait InteractsXmlTrait
             throw new InvalidArgumentException('Cannot load an xml with empty content');
         }
         $document = new DOMDocument();
-        $document->loadXML($source);
+        // as of libxml2 >= 1.11.0 it will truncate huge text nodes (like the zip files in base64)
+        $document->loadXML($source, LIBXML_PARSEHUGE);
         return $document;
     }
 

--- a/src/Shared/ComplementoTrait.php
+++ b/src/Shared/ComplementoTrait.php
@@ -40,7 +40,7 @@ trait ComplementoTrait
                 return $label;
             }
         }
-        return '';
+        return ''; // @codeCoverageIgnore
     }
 
     public function jsonSerialize(): string

--- a/tests/Unit/Services/Download/DownloadTranslatorContentsTest.php
+++ b/tests/Unit/Services/Download/DownloadTranslatorContentsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Services\Download;
+
+use LogicException;
+use PhpCfdi\SatWsDescargaMasiva\Services\Download\DownloadTranslator;
+use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use ZipArchive;
+
+final class DownloadTranslatorContentsTest extends TestCase
+{
+    private const FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10 MiB
+
+    /** @var string */
+    private $hugeZipFile;
+
+    /** @var string */
+    private $hugeResponse;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $hugeZipFile = tempnam('', '');
+        if (false === $hugeZipFile) {
+            throw new LogicException('Unable to create a temporary file');
+        }
+
+        $this->hugeZipFile = $hugeZipFile;
+        $this->createHugeZipFile($this->hugeZipFile);
+        $this->hugeResponse = $this->createHugeResponse($this->hugeZipFile);
+        if (strlen($this->hugeResponse) < self::FILE_SIZE_LIMIT) {
+            throw new LogicException(
+                sprintf('Unable to create a response with size bigger than %s bytes', self::FILE_SIZE_LIMIT)
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        unlink($this->hugeZipFile);
+        parent::tearDown();
+    }
+
+    private function createHugeZipFile(string $destination): void
+    {
+        $chunkSize = 2 * 1024 * 1024; // 1MB
+        $limitSize = self::FILE_SIZE_LIMIT; // 10MB
+        $fileCount = intval($limitSize / $chunkSize) + 1;
+        $archive = new ZipArchive();
+        $archive->open($destination, ZipArchive::OVERWRITE);
+        for ($i = 1; $i < $fileCount; $i++) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $archive->addFromString(sprintf('%d.txt', $i), random_bytes($chunkSize));
+        }
+        $archive->close();
+    }
+
+    private function createHugeResponse(string $contentFile): string
+    {
+        $template = $this->fileContents('download/response-with-package-template.xml');
+        $template = (string) preg_replace('/>\s+</', '><', $template);
+        $template = str_replace('?>', "?>\n", $template);
+        $search = '<Paquete />';
+        $strpos = (int) strpos($template, $search);
+        /** @noinspection PhpUnnecessaryLocalVariableInspection */
+        $template = substr($template, 0, $strpos)
+            . '<Paquete>' . base64_encode((string) file_get_contents($contentFile)) . '</Paquete>'
+            . substr($template, $strpos + strlen($search));
+        // file_put_contents('/tmp/sample-response.xml', $template);
+        return $template;
+    }
+
+    public function testCreateDownloadResultFromHugeResponse(): void
+    {
+        $translator = new DownloadTranslator();
+
+        $result = $translator->createDownloadResultFromSoapResponse($this->hugeResponse);
+
+        $this->assertSame(
+            sha1_file($this->hugeZipFile),
+            sha1($result->getPackageContent()),
+            'Extracted package contents for huge file are not the expected',
+        );
+    }
+}

--- a/tests/Unit/Shared/ComplementoCfdiTest.php
+++ b/tests/Unit/Shared/ComplementoCfdiTest.php
@@ -27,8 +27,10 @@ final class ComplementoCfdiTest extends TestCase
     {
         $complemento = ComplementoCfdi::valesDespensa10();
         $this->assertFalse($complemento->isUndefined());
+        $this->assertTrue($complemento->{'isValesDespensa10'}());
         $this->assertSame('valesdedespensa', $complemento->value());
         $this->assertSame('Vales de despensa 1.0', $complemento->label());
         $this->assertEquals(new ComplementoCfdi('valesdedespensa'), $complemento);
+        $this->assertEquals(ComplementoCfdi::create('valesdedespensa'), $complemento);
     }
 }

--- a/tests/Unit/Shared/ComplementoForTesting.php
+++ b/tests/Unit/Shared/ComplementoForTesting.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Shared;
+
+use Eclipxe\Enum\Enum;
+use PhpCfdi\SatWsDescargaMasiva\Shared\ComplementoInterface;
+use PhpCfdi\SatWsDescargaMasiva\Shared\ComplementoTrait;
+
+/**
+ * Class extending Enum and implementing ComplementoInterface to test ComplementoTrait
+ *
+ * @method static self undefined()
+ * @method static self foo10()
+ * @method static self bar20()
+ *
+ * @method bool isUndefined()
+ * @method bool isFoo10()
+ * @method bool isBar20()
+ */
+final class ComplementoForTesting extends Enum implements ComplementoInterface
+{
+    use ComplementoTrait;
+
+    private const MAP = [
+        self::UNDEFINED_KEY => self::UNDEFINED_VALUES,
+        'foo' => [
+            'satCode' => 'foo10',
+            'label' => 'Complemento Foo 1.0',
+        ],
+        'bar20' => [
+            'satCode' => 'bar20',
+            'label' => 'Complemento Bar 2.0',
+        ],
+    ];
+}

--- a/tests/Unit/Shared/ComplementoRetencionesTest.php
+++ b/tests/Unit/Shared/ComplementoRetencionesTest.php
@@ -27,8 +27,10 @@ final class ComplementoRetencionesTest extends TestCase
     {
         $complemento = ComplementoRetenciones::planesRetiro11();
         $this->assertFalse($complemento->isUndefined());
+        $this->assertTrue($complemento->{'isPlanesRetiro11'}());
         $this->assertSame('planesderetiro11', $complemento->value());
         $this->assertSame('Planes de retiro 1.1', $complemento->label());
         $this->assertEquals(new ComplementoRetenciones('planesderetiro11'), $complemento);
+        $this->assertEquals(ComplementoRetenciones::create('planesderetiro11'), $complemento);
     }
 }

--- a/tests/Unit/Shared/ComplementoTraitTest.php
+++ b/tests/Unit/Shared/ComplementoTraitTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Shared;
+
+use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+
+final class ComplementoTraitTest extends TestCase
+{
+    public function testCreateFactoryMethod(): void
+    {
+        $expectedLabels = [
+            '' => 'Sin complemento definido',
+            'foo10' => 'Complemento Foo 1.0',
+            'bar20' => 'Complemento Bar 2.0',
+        ];
+
+        $this->assertSame($expectedLabels, ComplementoForTesting::getLabels());
+    }
+}

--- a/tests/_files/download/response-with-package-template.xml
+++ b/tests/_files/download/response-with-package-template.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Header>
+        <h:respuesta CodEstatus="5000" Mensaje="Solicitud Aceptada" xmlns:h="http://DescargaMasivaTerceros.sat.gob.mx" xmlns="http://DescargaMasivaTerceros.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+    </s:Header>
+    <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <RespuestaDescargaMasivaTercerosSalida xmlns="http://DescargaMasivaTerceros.sat.gob.mx">
+            <Paquete />
+        </RespuestaDescargaMasivaTercerosSalida>
+    </s:Body>
+</s:Envelope>


### PR DESCRIPTION
- Se corrige un bug donde en algunas ocasiones falla al procesar la respuesta de una descarga de paquetes.

El método `DOMDocument::loadXML()` con `LibXML >= 1.11.0` trunca a 10,000,000 bytes el contenido de un
nodo de tipo texto. Esto lleva a que el contenido de un paquete se trunque y el archivo ZIP descargado
se encuentre truncado y, por lo tanto, corrupto. Se ha corregido usando la opción `LIBXML_PARSEHUGE`.
Al usar `LIBXML_PARSEHUGE` se está quitando una protección natural que impide una denegación de servicio.
Sin embargo, podemos considerar segura esta acción dado que solo ocurre en el contexto de respuestas
recibidas del servicio de descarga masiva del SAT.

- Se actualiza el archivo de licencia a 2024.

- Mantenimiento 2024-04-17

Se realizaron las siguientes tareas de mantenimiento:

- Se mejoran las pruebas del rasgo `ComplementoTrait`.
- Se actualizaron los flujos de trabajo:
  - Se agregó PHP 8.3 a la matriz de pruebas.
  - Los trabajos ahora corren en PHP 8.3.
  - Se actualizan las acciones de GitHub a la versión 4.
  - Se cambia la variable `build/tests/matrix/php-versions` a singular.
- Se actualizaron las herramientas de desarrollo.
