### PR TITLE
Allow to change the service token

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ Esta versión compatibiliza la versión actual con el nuevo servicio.
 Adicionalmente, se agrega un método de prevalidación para una consulta a través del método `QueryParameters::validate()`
 que devuelve un arreglo con una lista de mensajes con los errores encontrados.
 
+Se regresa la capacidad de cambiar el *token* en el *servicio.
+Es importante para poder restablecer el *token* desde una capa de persistencia.
+
 Gracias a todos los miembros de PhpCfdi que han colaborado con la elaboración de esta versión.
 En especial a `@blacktrue` y `@TheSpectroMx` por su atención y trabajo.
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -59,6 +59,11 @@ class Service
         return $this->token;
     }
 
+    public function setToken(Token $token): void
+    {
+        $this->token = $token;
+    }
+
     public function getEndpoints(): ServiceEndpoints
     {
         return $this->endpoints;

--- a/tests/Unit/ServiceTest.php
+++ b/tests/Unit/ServiceTest.php
@@ -39,4 +39,18 @@ final class ServiceTest extends TestCase
         $this->assertSame($token, $service->getToken());
         $this->assertSame($endpoints, $service->getEndpoints());
     }
+
+    public function testChangeToken(): void
+    {
+        $requestBuilder = $this->createMock(RequestBuilderInterface::class);
+        $webClient = $this->createMock(WebClientInterface::class);
+        $token = new Token(DateTime::now(), DateTime::now(), 'token-value');
+        $endpoints = ServiceEndpoints::retenciones();
+
+        $service = new Service($requestBuilder, $webClient, $token, $endpoints);
+        $otherToken = new Token(DateTime::now(), DateTime::now(), 'token-other');
+        $service->setToken($otherToken);
+
+        $this->assertSame($otherToken, $service->getToken());
+    }
 }


### PR DESCRIPTION
It is important to allow set the service token from a persistence layer.
Fixes `phpcfdi/sat-ws-descarga-masiva-cli`.
