### PR TITLE
Corregir las deprecaciones de PHP 8.4 (versión 1.1.2)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.75.0" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.88.2" installed="3.88.2" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^4.0.0" installed="4.0.0" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^4.0.0" installed="4.0.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^2.1.17" installed="2.1.17" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpstan" version="^2.1.29" installed="2.1.29" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP81Migration' => true,
-        '@PHP80Migration:risky' => true,
+        '@PHP8x1Migration' => true,
+        '@PHP8x0Migration:risky' => true,
         // symfony
         'array_indentation' => true,
         'class_attributes_separation' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,15 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
-## Mantenimiento 2025-09-25
+## Versión 1.1.2 2025-09-25
+
+- Se detecta que en PHP 8.4, para la llamada al método `SplFileObject::setCsvControl()` se debe establecer el parámetro
+  `$escape` dado que cambiará en futuras versiones.
+- Se hacen ajustes al entorno de desarrollo para sustituir las anotaciones por atributos.
+- Se actualizan los grupos de reglas de `php-cs-fixer` pues cambiaron de nombre.
+- Se actualizan las herramientas de desarrollo.
+
+Adicionalmente, se incluyen estos cambios hechos por mantenimiento:
 
 - Se actualizan las herramientas `phpcs` y `phpcbf` a la versión 4.0.0.
 - Se moderniza la integración con SonarQube-Cloud.

--- a/src/PackageReader/Internal/CsvReader.php
+++ b/src/PackageReader/Internal/CsvReader.php
@@ -32,7 +32,7 @@ final class CsvReader
         $iterator->fwrite($contents);
         $iterator->rewind();
         $iterator->setFlags(SplTempFileObject::READ_CSV);
-        $iterator->setCsvControl('~', '|');
+        $iterator->setCsvControl('~', '|', '\\');
         return $iterator;
     }
 

--- a/tests/Unit/PackageReader/CfdiPackageReaderTest.php
+++ b/tests/Unit/PackageReader/CfdiPackageReaderTest.php
@@ -8,6 +8,7 @@ use JsonSerializable;
 use PhpCfdi\SatWsDescargaMasiva\PackageReader\CfdiPackageReader;
 use PhpCfdi\SatWsDescargaMasiva\PackageReader\Exceptions\OpenZipFileException;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * This tests uses the Zip file located at tests/_files/zip/cfdi.zip that contains:
@@ -160,9 +161,7 @@ class CfdiPackageReaderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerObtainUuidFromXmlCfdi
-     */
+    #[DataProvider('providerObtainUuidFromXmlCfdi')]
     public function testObtainUuidFromXmlCfdi(string $source, string $expected): void
     {
         $uuid = CfdiPackageReader::obtainUuidFromXmlCfdi($source);

--- a/tests/Unit/PackageReader/MetadataContentTest.php
+++ b/tests/Unit/PackageReader/MetadataContentTest.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\PackageReader;
 
 use PhpCfdi\SatWsDescargaMasiva\PackageReader\Internal\MetadataContent;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MetadataContentTest extends TestCase
 {
@@ -46,9 +47,7 @@ class MetadataContentTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerReadMetadataWithSpecialCharacters
-     */
+    #[DataProvider('providerReadMetadataWithSpecialCharacters')]
     public function testReadMetadataWithSpecialCharacters(string $sourceValue, string $expectedValue): void
     {
         $contents = implode("\r\n", [

--- a/tests/Unit/Shared/AbstractRfcFilterTest.php
+++ b/tests/Unit/Shared/AbstractRfcFilterTest.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Shared;
 
 use InvalidArgumentException;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class AbstractRfcFilterTest extends TestCase
 {
@@ -33,7 +34,7 @@ final class AbstractRfcFilterTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerInvalidValues */
+    #[DataProvider('providerInvalidValues')]
     public function testConstructWithInvalidValue(string $value): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -46,7 +47,7 @@ final class AbstractRfcFilterTest extends TestCase
         $this->assertTrue(RfcFilterImplementation::check('XXX01010199A'));
     }
 
-    /** @dataProvider providerInvalidValues */
+    #[DataProvider('providerInvalidValues')]
     public function testCheckInvalidValue(string $value): void
     {
         $this->assertFalse(RfcFilterImplementation::check($value));

--- a/tests/Unit/Shared/ServiceTypeTest.php
+++ b/tests/Unit/Shared/ServiceTypeTest.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Shared;
 
 use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceType;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ServiceTypeTest extends TestCase
 {
@@ -27,7 +28,7 @@ final class ServiceTypeTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerServiceTypes */
+    #[DataProvider('providerServiceTypes')]
     public function testJsonEncode(ServiceType $serviceType): void
     {
         $json = json_encode($serviceType);

--- a/tests/Unit/Shared/UuidTest.php
+++ b/tests/Unit/Shared/UuidTest.php
@@ -7,6 +7,7 @@ namespace PhpCfdi\SatWsDescargaMasiva\Tests\Unit\Shared;
 use InvalidArgumentException;
 use PhpCfdi\SatWsDescargaMasiva\Shared\Uuid;
 use PhpCfdi\SatWsDescargaMasiva\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class UuidTest extends TestCase
 {
@@ -44,7 +45,7 @@ final class UuidTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerInvalidValues */
+    #[DataProvider('providerInvalidValues')]
     public function testConstructWithInvalidValue(string $value): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -57,7 +58,7 @@ final class UuidTest extends TestCase
         $this->assertTrue(Uuid::check('96623061-61fe-49de-b298-c7156476aa8b'));
     }
 
-    /** @dataProvider providerInvalidValues */
+    #[DataProvider('providerInvalidValues')]
     public function testCheckInvalidValue(string $value): void
     {
         $this->assertFalse(Uuid::check($value));


### PR DESCRIPTION
- Se detecta que en PHP 8.4, para la llamada al método `SplFileObject::setCsvControl()` se debe establecer el parámetro
  `$escape` dado que cambiará en futuras versiones.
- Se hacen ajustes al entorno de desarrollo para sustituir las anotaciones por atributos.
- Se actualizan los grupos de reglas de `php-cs-fixer` pues cambiaron de nombre.
- Se actualizan las herramientas de desarrollo.

Estos cambios ya se habían realizado, pero se documentan en esta versión:

- Se actualizan las herramientas `phpcs` y `phpcbf` a la versión 4.0.0.
- Se moderniza la integración con SonarQube-Cloud.
- Se actualiza `sonarqube-scan-action` a la versión 6.
- Las pruebas se ejecutan configurando la zona de tiempo a `America/Mexico_City`.
