### PR TITLE
PHP8.5 y mantenimiento (versión 1.1.3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           fail-fast: true
       - name: Composer normalize
-        run: composer-normalize
+        run: composer-normalize --dry-run
 
   phpcs:
     name: Code style (phpcs)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: PHPStan
         run: phpstan analyse --no-progress --verbose
 
-  tests:
+  phpunit:
     name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: composer-normalize
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -73,7 +73,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -82,7 +82,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "${{ steps.composer-cache.outputs.dir }}"
           key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
@@ -100,7 +100,7 @@ jobs:
         php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -113,7 +113,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "${{ steps.composer-cache.outputs.dir }}"
           key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"

--- a/.github/workflows/sonarqube-cloud.yml
+++ b/.github/workflows/sonarqube-cloud.yml
@@ -6,7 +6,7 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
-# SonarSource/sonarqube-scan-action@v6 https://github.com/marketplace/actions/official-sonarqube-scan
+# SonarSource/sonarqube-scan-action@v7 https://github.com/marketplace/actions/official-sonarqube-scan
 
 jobs:
 
@@ -21,20 +21,20 @@ jobs:
             exit 1
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: xdebug
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -48,6 +48,6 @@ jobs:
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/junit.xml > build/sonar-junit.xml
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/clover.xml > build/sonar-coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.88.2" installed="3.88.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^4.0.0" installed="4.0.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^4.0.0" installed="4.0.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^2.1.29" installed="2.1.29" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.94.2" installed="3.94.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.42" installed="2.1.42" location="./tools/phpstan" copy="false"/>
   <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2026 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,26 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `main-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## Versión 1.1.3 2026-04-07
+
+Esta es una actualización de mantenimiento que tiene cambios mínimos en el código y compatibilidad con PHP 8.5.
+Esta actualización corrige el *build* en GitHub.
+
+- Se actualiza el año de licencia.
+- Se modifican los tipos de `Request#jsonSerialize` y `Response#jsonSerialize`.
+- Se modifica `InteractsXmlTrait#findAttributes` para hacerla más entendible.
+
+Adicionalmente, se incluyen estos cambios hechos por mantenimiento:
+
+- Se actualiza la configuración de PHPUnit para que falle y muestre todos los detalles en cualquier incidencia.
+- En los flujos de trabajo de GitHub:
+  - Se actualiza `sonarqube-scan-action` a la versión 7.
+  - Se actualizan las acciones de GitHub a sus últimas versiones.
+  - Se incluye PHP 8.5 a la matriz de pruebas.
+  - Se actualizan los trabajos para ejecutarse en PHP 8.5.
+  - Se renombra el trabajo `tests` a `phpunit`.
+- Se actualizan herramientas de desarrollo.
+
 ## Versión 1.1.2 2025-09-25
 
 - Se detecta que en PHP 8.4, para la llamada al método `SplFileObject::setCsvControl()` se debe establecer el parámetro

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
   </testsuites>
   <source>
     <include>
-      <directory suffix=".php">src</directory>
+      <directory>src</directory>
     </include>
   </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,8 @@
   xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
   cacheDirectory="build/phpunit.cache"
   bootstrap="./tests/bootstrap.php"
+  failOnAllIssues="true"
+  displayDetailsOnAllIssues="true"
   colors="true"
   >
   <testsuites>

--- a/src/Internal/InteractsXmlTrait.php
+++ b/src/Internal/InteractsXmlTrait.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatWsDescargaMasiva\Internal;
 
-use DOMAttr;
 use DOMDocument;
 use DOMElement;
-use DOMNamedNodeMap;
 use DOMNode;
 use InvalidArgumentException;
 
@@ -83,9 +81,7 @@ trait InteractsXmlTrait
         return implode('', $buffer);
     }
 
-    /**
-     * @return DOMElement[]
-     */
+    /** @return DOMElement[] */
     public function findElements(DOMElement $element, string ...$names): array
     {
         $current = strtolower(strval(array_pop($names)));
@@ -129,15 +125,12 @@ trait InteractsXmlTrait
         if (null === $found) {
             return [];
         }
+
         $attributes = [];
-        /**
-         * @var DOMNamedNodeMap<DOMAttr> $elementAttributes
-         * phpstan doesn't know that $found->attributes cannot be null since $found is a DOMElement
-         */
-        $elementAttributes = $found->attributes;
-        foreach ($elementAttributes as $attribute) {
-            $attributes[$attribute->localName] = $attribute->value;
+        foreach ($found->attributes as $attribute) {
+            $attributeName = strtolower($attribute->localName ?? '');
+            $attributes[$attributeName] = $attribute->value;
         }
-        return array_change_key_case($attributes, CASE_LOWER);
+        return $attributes;
     }
 }

--- a/src/WebClient/Request.php
+++ b/src/WebClient/Request.php
@@ -16,8 +16,12 @@ final class Request implements JsonSerializable
      *
      * @param array<string, string> $headers
      */
-    public function __construct(private readonly string $method, private readonly string $uri, private readonly string $body, array $headers)
-    {
+    public function __construct(
+        private readonly string $method,
+        private readonly string $uri,
+        private readonly string $body,
+        array $headers,
+    ) {
         /** @var array<string, string> $headers */
         $headers = array_filter(array_merge($this->defaultHeaders(), $headers));
         $this->headers = $headers;
@@ -58,9 +62,21 @@ final class Request implements JsonSerializable
         ];
     }
 
-    /** @return array<string, mixed> */
+    /**
+     * @return array{
+     *     method: string,
+     *     uri: string,
+     *     headers: array<string, string>,
+     *     body: string
+     * }
+     */
     public function jsonSerialize(): array
     {
-        return get_object_vars($this);
+        return [
+            'method' => $this->method,
+            'uri' => $this->uri,
+            'headers' => $this->headers,
+            'body' => $this->body,
+        ];
     }
 }

--- a/src/WebClient/Response.php
+++ b/src/WebClient/Response.php
@@ -13,8 +13,11 @@ final class Response implements JsonSerializable
      *
      * @param array<string, string> $headers
      */
-    public function __construct(private readonly int $statusCode, private readonly string $body, private readonly array $headers = [])
-    {
+    public function __construct(
+        private readonly int $statusCode,
+        private readonly string $body,
+        private readonly array $headers = [],
+    ) {
     }
 
     public function getStatusCode(): int
@@ -48,9 +51,19 @@ final class Response implements JsonSerializable
         return $this->statusCode < 600 && $this->statusCode >= 500;
     }
 
-    /** @return array<string, mixed> */
+    /**
+     * @return array{
+     *     statusCode: int,
+     *     headers: array<string, string>,
+     *     body: string
+     * }
+     */
     public function jsonSerialize(): array
     {
-        return get_object_vars($this);
+        return [
+            'statusCode' => $this->statusCode,
+            'headers' => $this->headers,
+            'body' => $this->body,
+        ];
     }
 }


### PR DESCRIPTION
Esta es una actualización de mantenimiento que tiene cambios mínimos en el código y compatibilidad con PHP 8.5.
Esta actualización corrige el *build* en GitHub.

- Se actualiza el año de licencia.
- Se modifican los tipos de `Request#jsonSerialize` y `Response#jsonSerialize`.
- Se modifica `InteractsXmlTrait#findAttributes` para hacerla más entendible.

Adicionalmente, se incluyen estos cambios hechos por mantenimiento:

- Se actualiza la configuración de PHPUnit para que falle y muestre todos los detalles en cualquier incidencia.
- En los flujos de trabajo de GitHub:
  - Se actualiza `sonarqube-scan-action` a la versión 7.
  - Se actualizan las acciones de GitHub a sus últimas versiones.
  - Se incluye PHP 8.5 a la matriz de pruebas.
  - Se actualizan los trabajos para ejecutarse en PHP 8.5.
  - Se renombra el trabajo `tests` a `phpunit`.
- Se actualizan herramientas de desarrollo.
